### PR TITLE
Ultimate genomics BAM tags

### DIFF
--- a/src/leviosam.cpp
+++ b/src/leviosam.cpp
@@ -201,8 +201,8 @@ void read_and_lift(T *lift_map, std::mutex *mutex_fread,
 
             // Tags specific to Ultima Genomics reads
             if (args.is_ultima_genomics == true) {
-                bool reversely_lifted = (aln_vec_clone[i]->core.flag & BAM_FREVERSE) ^
-                                        (aln_vec[i]->core.flag & BAM_FREVERSE);
+                bool reversely_lifted = LevioSamUtils::is_reversedly_lifted(
+                    aln_vec_clone[i], aln_vec[i]);
                 LevioSamUtils::update_ultima_genomics_tags(aln_vec[i],
                                                            reversely_lifted);
             }

--- a/src/leviosam.cpp
+++ b/src/leviosam.cpp
@@ -591,7 +591,7 @@ int main(int argc, char **argv) {
         {"vcf", required_argument, 0, 'v'},
         {"verbose", required_argument, 0, 'V'},
         {"realign_yaml", required_argument, 0, 'x'},
-        {"is_ultima_genomics", no_argument, 0, OPT_IS_ULTIMA_GENOMICS},
+        {"ultima_genomics", no_argument, 0, OPT_ULTIMA_GENOMICS},
         {"help", no_argument, 0, OPT_HELP},
         {"version", no_argument, 0, OPT_VERSION},
         {"keep_mapq", no_argument, 0, OPT_KEEP_MAPQ}};

--- a/src/leviosam.cpp
+++ b/src/leviosam.cpp
@@ -581,6 +581,7 @@ int main(int argc, char **argv) {
             {"vcf", required_argument, 0, 'v'},
             {"verbose", required_argument, 0, 'V'},
             {"realign_yaml", required_argument, 0, 'x'},
+            {"help", no_argument, 0, OPT_HELP},
             {"version", no_argument, 0, OPT_VERSION},
             {"keep_mapq", no_argument, 0, OPT_KEEP_MAPQ}
     };
@@ -590,6 +591,7 @@ int main(int argc, char **argv) {
                             long_options, &long_index)) != -1) {
         switch (c) {
             case 'h':
+            case OPT_HELP:
                 print_main_help_msg();
                 print_serialize_help_msg();
                 print_lift_help_msg();

--- a/src/leviosam.cpp
+++ b/src/leviosam.cpp
@@ -200,7 +200,7 @@ void read_and_lift(T *lift_map, std::mutex *mutex_fread,
             bam_fillmd1(aln_vec[i], ref.data(), args.md_flag, 1);
 
             // Tags specific to Ultima Genomics reads
-            if (args.is_ultima_genomics == true) {
+            if (args.ultima_genomics == true) {
                 bool reversely_lifted = LevioSamUtils::is_reversedly_lifted(
                     aln_vec_clone[i], aln_vec[i]);
                 LevioSamUtils::update_ultima_genomics_tags(aln_vec[i],
@@ -682,8 +682,8 @@ int main(int argc, char **argv) {
             case 'x':
                 args.realign_yaml = optarg;
                 break;
-            case OPT_IS_ULTIMA_GENOMICS:
-                args.is_ultima_genomics = true;
+            case OPT_ULTIMA_GENOMICS:
+                args.ultima_genomics = true;
                 break;
             case OPT_VERSION:
                 std::cout << VERSION << std::endl;

--- a/src/leviosam.hpp
+++ b/src/leviosam.hpp
@@ -37,6 +37,7 @@
 #define OPT_HELP 1000
 #define OPT_VERSION 1001
 #define OPT_KEEP_MAPQ 1002
+#define OPT_IS_ULTIMA_GENOMICS 2001
 
 using NameMap = std::vector<std::pair<std::string, std::string>>;
 using LengthMap = std::vector<std::pair<std::string, int32_t>>;
@@ -82,6 +83,8 @@ struct lift_opts {
     // 0: take any overlap, >1: base pairs, 1>=value>0: fraction
     float bed_isec_threshold = 0;
     bool keep_mapq = false;
+
+    bool is_ultima_genomics = false;
 };
 
 #define LIFT_R_L 0           // unpaired, liftable

--- a/src/leviosam.hpp
+++ b/src/leviosam.hpp
@@ -84,7 +84,7 @@ struct lift_opts {
     float bed_isec_threshold = 0;
     bool keep_mapq = false;
 
-    bool is_ultima_genomics = false;
+    bool ultima_genomics = false;
 };
 
 #define LIFT_R_L 0           // unpaired, liftable

--- a/src/leviosam.hpp
+++ b/src/leviosam.hpp
@@ -37,7 +37,7 @@
 #define OPT_HELP 1000
 #define OPT_VERSION 1001
 #define OPT_KEEP_MAPQ 1002
-#define OPT_IS_ULTIMA_GENOMICS 2001
+#define OPT_ULTIMA_GENOMICS 2001
 
 using NameMap = std::vector<std::pair<std::string, std::string>>;
 using LengthMap = std::vector<std::pair<std::string, int32_t>>;

--- a/src/leviosam.hpp
+++ b/src/leviosam.hpp
@@ -34,8 +34,9 @@
 #define VERBOSE_DEBUG 2
 #define VERBOSE_DEV 3
 
-#define OPT_VERSION 1000
-#define OPT_KEEP_MAPQ 1001
+#define OPT_HELP 1000
+#define OPT_VERSION 1001
+#define OPT_KEEP_MAPQ 1002
 
 using NameMap = std::vector<std::pair<std::string, std::string>>;
 using LengthMap = std::vector<std::pair<std::string, int32_t>>;

--- a/src/leviosam_test.cpp
+++ b/src/leviosam_test.cpp
@@ -359,10 +359,6 @@ TEST(UltimaGenomicsTest, UpdateFlags) {
     EXPECT_EQ(err, 0);
     LevioSamUtils::update_ultima_genomics_tags(aln, true);
 
-    samFile* t_sam_fp = sam_open("tmp_ultima_small.sam", "w");
-    sam_hdr_write(t_sam_fp, sam_hdr);
-    sam_write1(t_sam_fp, sam_hdr, aln);
-
     // Tests the tp tag
     uint8_t *tp_ptr = bam_aux_get(aln, "tp");
     EXPECT_EQ(bam_auxB_len(tp_ptr), 10);
@@ -380,7 +376,6 @@ TEST(UltimaGenomicsTest, UpdateFlags) {
 
     sam_hdr_destroy(sam_hdr);
     sam_close(sam_fp);
-    sam_close(t_sam_fp);
 }
 
 

--- a/src/leviosam_test.cpp
+++ b/src/leviosam_test.cpp
@@ -348,6 +348,42 @@ TEST(UtilsTest, UpdateFlagUnmap) {
     sam_close(sam_fp);
 }
 
+
+TEST(UltimaGenomicsTest, UpdateFlags) {
+    samFile* sam_fp = sam_open("ultima_small.sam", "r");
+    sam_hdr_t* sam_hdr = sam_hdr_read(sam_fp);
+    bam1_t* aln = bam_init1();
+    int err;
+    size_t x;
+    err = sam_read1(sam_fp, sam_hdr, aln);
+    EXPECT_EQ(err, 0);
+    LevioSamUtils::update_ultima_genomics_tags(aln, true);
+
+    samFile* t_sam_fp = sam_open("tmp_ultima_small.sam", "w");
+    sam_hdr_write(t_sam_fp, sam_hdr);
+    sam_write1(t_sam_fp, sam_hdr, aln);
+
+    // Tests the tp tag
+    uint8_t *tp_ptr = bam_aux_get(aln, "tp");
+    EXPECT_EQ(bam_auxB_len(tp_ptr), 10);
+    std::vector<int8_t> exp_tp_array {
+        -1,-1,0,1,-1,1,1,1,1,-1
+    };
+    for (uint32_t i = 0; i < 10; i++) {
+        EXPECT_EQ(bam_auxB2i(tp_ptr, i), exp_tp_array[i]); 
+    }
+
+    // Tests the t0 tag
+    uint8_t *t0_ptr = bam_aux_get(aln, "t0");
+    std::string t0_str = bam_aux2Z(t0_ptr);
+    EXPECT_EQ(t0_str, "IIIII22222");
+
+    sam_hdr_destroy(sam_hdr);
+    sam_close(sam_fp);
+    sam_close(t_sam_fp);
+}
+
+
 int main(int argc, char **argv){
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/src/leviosam_utils.cpp
+++ b/src/leviosam_utils.cpp
@@ -425,16 +425,28 @@ void update_ultima_genomics_tags(bam1_t* aln, bool rev) {
         if (bam_aux_update_array(aln, "tp", 'c', tp_array.size(),
                                  tp_array.data()) != 0) {
             std::cerr << "[W::update_ultima_genomics_tags] Failed to update "
-                         "the tp tag\n";
+                         "the tp tag for read "
+                      << bam_get_qname(aln) << "\n";
         }
+    } else {
+        std::cerr
+            << "[W::update_ultima_genomics_tags] No tp tag is found for read "
+            << bam_get_qname(aln) << "\n";
     }
     // T0 tag
     uint8_t* t0_ptr = bam_aux_get(aln, "t0");
-    std::string t0_str = bam_aux2Z(t0_ptr);
-    std::reverse(t0_str.begin(), t0_str.end());
-    if (bam_aux_update_str(aln, "t0", t0_str.length(), t0_str.c_str()) != 0) {
-        std::cerr << "[W::update_ultima_genomics_tags] Failed to update "
-                     "the t0 tag\n";
+    if (t0_ptr != NULL) {
+        std::string t0_str = bam_aux2Z(t0_ptr);
+        std::reverse(t0_str.begin(), t0_str.end());
+        if (bam_aux_update_str(aln, "t0", t0_str.length(), t0_str.c_str()) !=
+            0) {
+            std::cerr << "[W::update_ultima_genomics_tags] Failed to update "
+                         "the t0 tag\n";
+        }
+    } else {
+        std::cerr
+            << "[W::update_ultima_genomics_tags] No t0 tag is found for read "
+            << bam_get_qname(aln) << "\n";
     }
 }
 

--- a/src/leviosam_utils.cpp
+++ b/src/leviosam_utils.cpp
@@ -402,6 +402,20 @@ std::set<std::string> str_to_set(const std::string str,
     return list;
 }
 
+/* Updates BAM tags specific to Ultima Genomics.*/
+void update_ultima_genomics_tags(bam1_t *aln, bool rev) { 
+    uint8_t *tp_ptr = bam_aux_get(aln, "tp");
+    if (tp_ptr != NULL) {
+        std::vector<int8_t> tp_array;
+        for (int8_t i = 0; i < bam_auxB_len(tp_ptr); i++) {
+            tp_array.push_back(bam_auxB2i(tp_ptr, i));
+        }
+        std::reverse(tp_array.begin(),tp_array.end());
+        bam_aux_update_array(aln, "tp", 'c', tp_array.size(), tp_array.data());
+    }
+    // uint8_t *t0_ptr = bam_aux_get(aln, "t0");
+}
+
 /* Update SEQ and QUAL if in a reversed chain */
 int reverse_seq_and_qual(bam1_t* aln) {
     bam1_core_t* c = &(aln->core);

--- a/src/leviosam_utils.hpp
+++ b/src/leviosam_utils.hpp
@@ -128,6 +128,8 @@ std::vector<std::string> str_to_vector(const std::string str,
 std::set<std::string> str_to_set(const std::string str,
                                  const std::string regex_str);
 
+void update_ultima_genomics_tags(bam1_t *aln, bool rev);
+
 int reverse_seq_and_qual(bam1_t* aln);
 sam_hdr_t* fai_to_hdr(std::string fai_fn, const sam_hdr_t* const hdr_orig);
 std::vector<std::pair<std::string, int32_t>> fai_to_map(std::string fai_fn);

--- a/src/leviosam_utils.hpp
+++ b/src/leviosam_utils.hpp
@@ -128,6 +128,10 @@ std::vector<std::string> str_to_vector(const std::string str,
 std::set<std::string> str_to_set(const std::string str,
                                  const std::string regex_str);
 
+/// @brief Returns true if a bam record is reversely lifted. 
+bool is_reversedly_lifted(bam1_t* aln_orig, bam1_t* aln_lft);
+
+/// @brief Updates BAM tags specific to Ultima Genomics.
 void update_ultima_genomics_tags(bam1_t *aln, bool rev);
 
 int reverse_seq_and_qual(bam1_t* aln);

--- a/testdata/ultima_small.sam
+++ b/testdata/ultima_small.sam
@@ -1,0 +1,3 @@
+@HD	VN:1.6	GO:query	SO:coordinate
+@SQ	SN:chr1	LN:100000
+1	16	chr1	200	0	10M	*	0	0	AACCCTAACC	7777IIIIII	t0:Z:22222IIIII	tm:Z:Q	tp:B:c,-1,1,1,1,1,-1,1,0,-1,-1	rq:f:0.14	RG:Z:test

--- a/workflow/leviosam2.sh
+++ b/workflow/leviosam2.sh
@@ -371,7 +371,6 @@ else
             ${PFX}-committed-sorted.bam ${PFX}-paired-deferred-reconciled-sorted.bam
         ${MT} samtools index ${PFX}-final.bam
     fi
-    samtools index ${PFX}-final.bam
 
     # Clean tmp files
     if [[ ${KEEP_TMP} < 1 ]]; then

--- a/workflow/leviosam2.sh
+++ b/workflow/leviosam2.sh
@@ -371,6 +371,7 @@ else
             ${PFX}-committed-sorted.bam ${PFX}-paired-deferred-reconciled-sorted.bam
         ${MT} samtools index ${PFX}-final.bam
     fi
+    samtools index ${PFX}-final.bam
 
     # Clean tmp files
     if [[ ${KEEP_TMP} < 1 ]]; then

--- a/workflow/leviosam2.sh
+++ b/workflow/leviosam2.sh
@@ -365,6 +365,12 @@ else
                 -o ${PFX}-paired-deferred-reconciled-sorted.bam
     fi
 
+    # if [ ! -s ${PFX}-paired-deferred-reconciled-sorted.bam ]; then
+    #     ${MT} samtools sort -@ ${THR} \
+    #         -o ${PFX}-paired-deferred-reconciled-sorted.bam \
+    #         ${PFX}-paired-deferred-reconciled.bam
+    # fi
+
     # Merge, sort, and clean
     if [ ! -s ${PFX}-final.bam ]; then
         ${MT} samtools merge -@ ${THR} --write-index -o ${PFX}-final.bam \

--- a/workflow/leviosam2.sh
+++ b/workflow/leviosam2.sh
@@ -365,12 +365,6 @@ else
                 -o ${PFX}-paired-deferred-reconciled-sorted.bam
     fi
 
-    # if [ ! -s ${PFX}-paired-deferred-reconciled-sorted.bam ]; then
-    #     ${MT} samtools sort -@ ${THR} \
-    #         -o ${PFX}-paired-deferred-reconciled-sorted.bam \
-    #         ${PFX}-paired-deferred-reconciled.bam
-    # fi
-
     # Merge, sort, and clean
     if [ ! -s ${PFX}-final.bam ]; then
         ${MT} samtools merge -@ ${THR} --write-index -o ${PFX}-final.bam \


### PR DESCRIPTION
This PR enables updating strand-specific tags (`tp` and `t0`) used by Ultima Genomics bam files, described in https://github.com/milkschen/leviosam2/issues/35 

To use this, add the `ultima_genomics` flag with `leviosam2 lift`.