### PR TITLE
Calculates the ref length of mate read using "MC:Z" when available

### DIFF
--- a/.github/workflows/cmake_htslib.yml
+++ b/.github/workflows/cmake_htslib.yml
@@ -29,7 +29,7 @@ jobs:
   htslib_matrix:
     strategy:
       matrix:
-        version: [1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18]
+        version: [1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18]
         os: [ubuntu-22.04, ubuntu-20.04, ubuntu-latest]
     
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ levioSAM2 supports a variety of methods for installation:
 
 ## Conda
 
-```
+```shell
 conda install -c conda-forge -c bioconda leviosam2
 ```
 
@@ -17,13 +17,13 @@ conda install -c conda-forge -c bioconda leviosam2
 
 You can obtain a Docker image of the latest version from Docker hub:
 
-```
+```shell
 docker pull naechyun/leviosam2:latest
 ```
 
 ## Singularity
 
-```
+```shell
 singularity pull docker://naechyun/leviosam2:latest
 ```
 
@@ -33,34 +33,37 @@ singularity pull docker://naechyun/leviosam2:latest
 
 Make sure the following prerequisite libraries are installed on your system. 
 
-- [htslib v1.11+ (tested up to v1.16)](https://github.com/samtools/htslib)
+- [htslib v1.12+ (tested up to v1.18)](https://github.com/samtools/htslib)
 - [sdsl-lite v2.1.1+](https://github.com/simongog/sdsl-lite/)
 
 Both libraries are available through coda:
-```
+
+```shell
 conda install -c conda-forge sdsl-lite
 conda install -c bioconda htslib
 ```
 
 Another easy way to install these dependencies is to use your OS's existing package system:
-```
+
+```shell
 apt-get install libhts-dev libsdsl-dev # Debian/Ubuntu
 brew tap brewsci/bio; brew install htslib sdsl-lite # MacOS
 ```
 
 If using RedHat or Fedora, then you must install sdsl-lite manually. But you can install htslib through yum:
-```
+
+```shell
 yum install htslib
 ```
 
 Or you can choose to install them manually by following the install instructions on their respective pages.
 
-### CMake 
+### CMake
 
 Once the prerequisite packages are installed and the locations of their installations are known, specify their locations
 to CMake by running the following commands:
 
-```
+```shell
 mkdir build
 cd build
 cmake ..
@@ -73,11 +76,10 @@ make
 If you installed the dependencies manually, you might have to modify the `cmake` command to specify their library and
 include directory locations like so:
 
-```
+```shell
 cmake -D CMAKE_LIBRARY_PATH="/path/to/libsdsl/;/path/to/libhts/" \
       -D CMAKE_INCLUDE_PATH="/path/to/libsdsl/include/;/path/to/libhts/include/" ..
 ```
-
 
 ## Test
 
@@ -86,7 +88,6 @@ We provide an end-to-end test and a set of unit tests for levioSAM.
 - The end-to-end test can be run with `python leviosam-test.py`. This test includes running levioSAM on several test files in `testdata`. We also use `picard` to test if the lifted SAM files are valid.
 
 - The unit test can be run `cd build; ctest` if you use cmake to build levioSAM; or `make gtest; cd testdata; ../gtest` if you use make to build levioSAM2.
-
 
 ## ARM64
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
+# LevioSAM2: Fast and accurate coordinate conversion between assemblies
+
 [![Docker](https://img.shields.io/docker/v/naechyun/leviosam2?label=Docker)](https://hub.docker.com/r/naechyun/leviosam2)
 [![Anaconda-Server Badge](https://anaconda.org/bioconda/leviosam2/badges/version.svg)](https://anaconda.org/bioconda/leviosam2)
 [![Anaconda-Server Badge](https://anaconda.org/bioconda/leviosam2/badges/downloads.svg)](https://anaconda.org/bioconda/leviosam2)
 ![Cmake build](https://github.com/milkschen/leviosam2/actions/workflows/cmake_htslib.yml/badge.svg)
 ![Integration](https://github.com/milkschen/leviosam2/actions/workflows/integration-test.yml/badge.svg)
-
-# LevioSAM2: Fast and accurate coordinate conversion between assemblies
 
 LevioSAM2 lifts over alignments accurately and efficiently using a chain file.
 
@@ -17,9 +17,9 @@ LevioSAM2 lifts over alignments accurately and efficiently using a chain file.
 
 - Converting aligned short and long reads records (in SAM/BAM/CRAM format) from one reference to another
 - Comprehensive alignment feature updating during lift-over:
-    - Reference name (`RNAME`), position (`POS`), alignmant flag (`FLAG`), and CIGAR alignment string (`CIGAR`)
-    - Mate read information (`RNEXT`, `PNEXT`, `TLEN`)
-    - (optional) Alignment tags (`MD:Z`, `NM:i`)
+  - Reference name (`RNAME`), position (`POS`), alignmant flag (`FLAG`), and CIGAR alignment string (`CIGAR`)
+  - Mate read information (`RNEXT`, `PNEXT`, `TLEN`)
+  - (optional) Alignment tags (`MD:Z`, `NM:i`)
 - Multithreading support
 - Toolkit for "selective" pipelines which consider major changes between the source and target references
 - (beta) Converting intervals (in BED format) from one reference to another
@@ -30,7 +30,7 @@ LevioSAM2 can be installed using:
 
 - [Conda](https://anaconda.org/bioconda/leviosam2)
 
-```
+```shell
 # The following commands install leviosam2 in a new conda environment called `leviosam2`
 conda create -n leviosam2
 conda activate leviosam2
@@ -38,12 +38,14 @@ conda install -c bioconda -c conda-forge leviosam2
 ```
 
 - [Docker](https://hub.docker.com/r/naechyun/leviosam2)
-```
+
+```shell
 docker pull naechyun/leviosam2:latest
 ```
 
 - [Singularity](https://hub.docker.com/r/naechyun/leviosam2)
-```
+
+```shell
 singularity pull docker://naechyun/leviosam2:latest
 ```
 
@@ -62,7 +64,7 @@ For other reference pairs, common ways to generate chain files include using the
 
 LevioSAM2 indexes a chain file for lift-over queries. The resulting index has a `.clft` extension.
 
-```
+```shell
 leviosam2 index -c source_to_target.chain -p source_to_target -F target.fai
 ```
 
@@ -73,17 +75,17 @@ The levioSAM2 ChainMap index will be saved to `source_to_target.clft`. The outpu
 
 __We highly recommend to sort the input BAM by position prior to running levioSAM2-lift.__
 
-```
+```shell
 leviosam2 lift -C source_to_target.clft -a aligned_to_source.bam -p lifted_from_source -O bam
 ```
-
 
 ### Full levioSAM2 workflow with selective re-mapping
 
 The levioSAM2 workflow includes lift-over using the `leviosam2-lift` kernel and a selective re-mapping strategy. This approach can improve accuracy.
 
 Example:
-```
+
+```shell
 # You may skip the indexing step if you've already run it
 leviosam2 index -c source_to_target.chain -p source_to_target -F target.fai
 sh leviosam2.sh \
@@ -98,10 +100,9 @@ sh leviosam2.sh \
 
 See [this README](https://github.com/milkschen/leviosam2/blob/main/workflow/README.md) to learn more about running the full levioSAM2 workflow.
 
-
 ## Publication
 
--  Nae-Chyun Chen, Luis Paulin, Fritz Sedlazeck, Sergey Koren, Adam Phillippy, Ben Langmead. Improved sequence mapping using a complete reference genome and lift-over. Nat Methods (2023). https://doi.org/10.1038/s41592-023-02069-6
+- Nae-Chyun Chen, Luis Paulin, Fritz Sedlazeck, Sergey Koren, Adam Phillippy, Ben Langmead. Improved sequence mapping using a complete reference genome and lift-over. Nat Methods (2023). https://doi.org/10.1038/s41592-023-02069-6
 - Taher Mun, Nae-Chyun Chen, Ben Langmead. LevioSAM: Fast lift-over of variant-aware reference alignments, _Bioinformatics_, 2021;, btab396, https://doi.org/10.1093/bioinformatics/btab396
 
 _Logo credit: Ting-Wei Young_

--- a/src/chain_test.cpp
+++ b/src/chain_test.cpp
@@ -18,11 +18,6 @@
 #include "gtest/gtest.h"
 #include "leviosam_utils.hpp"
 
-size_t kstr_get_m(size_t var) {
-    size_t lvar = (size_t)exp2(ceil(log2(var)));
-    return lvar;
-}
-
 /* Chain tests */
 TEST(ChainTest, SimpleRankAndLift) {
     std::vector<std::pair<std::string, int32_t>> lm;

--- a/src/leviosam.cpp
+++ b/src/leviosam.cpp
@@ -220,7 +220,7 @@ void read_and_lift(T *lift_map, std::mutex *mutex_fread,
                 ref.substr(aln_vec[i]->core.pos,
                            bam_cigar2rlen(aln_vec[i]->core.n_cigar,
                                           bam_get_cigar(aln_vec[i])));
-            std::string q_seq = LevioSamUtils::get_read_as_is(aln_vec[i]);
+            std::string q_seq = LevioSamUtils::get_read(aln_vec[i]);
             std::vector<uint32_t> new_cigar;
             // We perform global alignment for local sequences and
             // thus an alignment with a high number of clipped bases

--- a/src/leviosam_test.cpp
+++ b/src/leviosam_test.cpp
@@ -9,15 +9,17 @@
  * Distributed under the MIT license
  * https://github.com/milkschen/leviosam2
  */
-#include <iostream>
-#include <unistd.h>
-#include <string>
 #include "leviosam.hpp"
-#include "leviosam_utils.hpp"
-#include "htslib/sam.h"
-#include "gtest/gtest.h"
-#include "bed.hpp"
 
+#include <unistd.h>
+
+#include <iostream>
+#include <string>
+
+#include "bed.hpp"
+#include "gtest/gtest.h"
+#include "htslib/sam.h"
+#include "leviosam_utils.hpp"
 
 //
 // bit_vector tests
@@ -30,7 +32,7 @@ TEST(BitVector, SimpleCreateAndAccess) {
     sdsl::bit_vector bv(n, 0);
     EXPECT_EQ(0, bv[0]);
     EXPECT_EQ(0, bv[500]);
-    EXPECT_EQ(0, bv[10000-1]);
+    EXPECT_EQ(0, bv[10000 - 1]);
 }
 
 TEST(BitVector, WriteAndRead) {
@@ -38,14 +40,14 @@ TEST(BitVector, WriteAndRead) {
     sdsl::bit_vector bv(n, 0);
     bv[0] = 1;
     bv[500] = 1;
-    bv[10000-1] = 1;
+    bv[10000 - 1] = 1;
     EXPECT_EQ(1, bv[0]);
     EXPECT_EQ(0, bv[1]);
     EXPECT_EQ(0, bv[499]);
     EXPECT_EQ(1, bv[500]);
     EXPECT_EQ(0, bv[501]);
-    EXPECT_EQ(0, bv[10000-2]);
-    EXPECT_EQ(1, bv[10000-1]);
+    EXPECT_EQ(0, bv[10000 - 2]);
+    EXPECT_EQ(1, bv[10000 - 1]);
 }
 
 TEST(BitVector, RankSupport) {
@@ -53,7 +55,7 @@ TEST(BitVector, RankSupport) {
     sdsl::bit_vector bv(n, 0);
     bv[0] = 1;
     bv[500] = 1;
-    bv[10000-1] = 1;
+    bv[10000 - 1] = 1;
     sdsl::rank_support_v<> rs(&bv);
     EXPECT_EQ(0, rs.rank(0));
     EXPECT_EQ(1, rs.rank(1));
@@ -62,19 +64,19 @@ TEST(BitVector, RankSupport) {
     EXPECT_EQ(1, rs.rank(500));
     EXPECT_EQ(2, rs.rank(501));
     EXPECT_EQ(2, rs.rank(601));
-    EXPECT_EQ(2, rs.rank(10000-1));
-    EXPECT_EQ(3, rs.rank(10000-0));
+    EXPECT_EQ(2, rs.rank(10000 - 1));
+    EXPECT_EQ(3, rs.rank(10000 - 0));
 }
 
 TEST(BitVector, SelectSupport) {
     sdsl::bit_vector bv(10000, 0);
     bv[0] = 1;
     bv[500] = 1;
-    bv[10000-1] = 1;
+    bv[10000 - 1] = 1;
     sdsl::bit_vector::select_1_type ss(&bv);
     EXPECT_EQ(0, ss.select(1));
     EXPECT_EQ(500, ss.select(2));
-    EXPECT_EQ(10000-1, ss.select(3));
+    EXPECT_EQ(10000 - 1, ss.select(3));
 }
 
 TEST(CompressedVector, CreateAndRead) {
@@ -82,15 +84,15 @@ TEST(CompressedVector, CreateAndRead) {
     sdsl::bit_vector bv(n, 0);
     bv[0] = 1;
     bv[500] = 1;
-    bv[10000-1] = 1;
+    bv[10000 - 1] = 1;
     sdsl::sd_vector<> sv{bv};
     EXPECT_EQ(1, sv[0]);
     EXPECT_EQ(0, sv[1]);
     EXPECT_EQ(0, sv[499]);
     EXPECT_EQ(1, sv[500]);
     EXPECT_EQ(0, sv[501]);
-    EXPECT_EQ(0, sv[10000-2]);
-    EXPECT_EQ(1, sv[10000-1]);
+    EXPECT_EQ(0, sv[10000 - 2]);
+    EXPECT_EQ(1, sv[10000 - 1]);
 
     sdsl::rrr_vector<63> rv{bv};
     EXPECT_EQ(1, rv[0]);
@@ -98,8 +100,8 @@ TEST(CompressedVector, CreateAndRead) {
     EXPECT_EQ(0, rv[499]);
     EXPECT_EQ(1, rv[500]);
     EXPECT_EQ(0, rv[501]);
-    EXPECT_EQ(0, rv[10000-2]);
-    EXPECT_EQ(1, rv[10000-1]);
+    EXPECT_EQ(0, rv[10000 - 2]);
+    EXPECT_EQ(1, rv[10000 - 1]);
 }
 
 TEST(CompressedVector, RankSupport) {
@@ -107,7 +109,7 @@ TEST(CompressedVector, RankSupport) {
     sdsl::bit_vector bv(n, 0);
     bv[0] = 1;
     bv[500] = 1;
-    bv[10000-1] = 1;
+    bv[10000 - 1] = 1;
     sdsl::sd_vector<> sv{bv};
     sdsl::sd_vector<>::rank_1_type rs(&sv);
     EXPECT_EQ(0, rs.rank(0));
@@ -117,20 +119,20 @@ TEST(CompressedVector, RankSupport) {
     EXPECT_EQ(1, rs.rank(500));
     EXPECT_EQ(2, rs.rank(501));
     EXPECT_EQ(2, rs.rank(601));
-    EXPECT_EQ(2, rs.rank(10000-1));
-    EXPECT_EQ(3, rs.rank(10000-0));
+    EXPECT_EQ(2, rs.rank(10000 - 1));
+    EXPECT_EQ(3, rs.rank(10000 - 0));
 }
 
 TEST(CompressedVector, SelectSupport) {
     sdsl::bit_vector bv(10000, 0);
     bv[0] = 1;
     bv[500] = 1;
-    bv[10000-1] = 1;
+    bv[10000 - 1] = 1;
     sdsl::sd_vector<> sv{bv};
     sdsl::sd_vector<>::select_1_type ss{&sv};
     EXPECT_EQ(0, ss.select(1));
     EXPECT_EQ(500, ss.select(2));
-    EXPECT_EQ(10000-1, ss.select(3));
+    EXPECT_EQ(10000 - 1, ss.select(3));
 }
 
 /* Lift tests */
@@ -138,7 +140,7 @@ TEST(CompressedVector, SelectSupport) {
 TEST(Lift, EmptyLift) {
     sdsl::bit_vector ibv;
     sdsl::bit_vector dbv;
-    sdsl::bit_vector sbv; // ins, del, snp
+    sdsl::bit_vector sbv;  // ins, del, snp
     ibv.resize(20);
     dbv.resize(20);
     sbv.resize(20);
@@ -149,7 +151,7 @@ TEST(Lift, EmptyLift) {
 TEST(Lift, SimpleInsLift) {
     sdsl::bit_vector ibv;
     sdsl::bit_vector dbv;
-    sdsl::bit_vector sbv; // ins, del, snp
+    sdsl::bit_vector sbv;  // ins, del, snp
     ibv.resize(20);
     dbv.resize(20);
     sbv.resize(20);
@@ -165,7 +167,7 @@ TEST(Lift, SimpleInsLift) {
 TEST(Lift, SimpleDelLift) {
     sdsl::bit_vector ibv;
     sdsl::bit_vector dbv;
-    sdsl::bit_vector sbv; // ins, del, snp
+    sdsl::bit_vector sbv;  // ins, del, snp
     ibv.resize(20);
     dbv.resize(20);
     sbv.resize(20);
@@ -177,7 +179,6 @@ TEST(Lift, SimpleDelLift) {
     lift::Lift lift(ibv, dbv, sbv);
     EXPECT_EQ(lift.lift_pos(6), 7);
 }
-
 
 TEST(LiftMap, SimpleBamLift) {
     vcfFile* vcf_fp = bcf_open("simple_example.vcf", "r");
@@ -214,18 +215,18 @@ TEST(LiftMap, SimpleBamCigarLift) {
     lmap.lift_cigar(sam_hdr->target_name[aln->core.tid], aln);
     test_cigar = bam_get_cigar(aln);
     EXPECT_EQ(aln->core.n_cigar, 3);
-    EXPECT_EQ(test_cigar[0], bam_cigar_gen( 11, BAM_CMATCH));
-    EXPECT_EQ(test_cigar[1], bam_cigar_gen( 2, BAM_CDEL));
-    EXPECT_EQ(test_cigar[2], bam_cigar_gen( 9, BAM_CMATCH));
+    EXPECT_EQ(test_cigar[0], bam_cigar_gen(11, BAM_CMATCH));
+    EXPECT_EQ(test_cigar[1], bam_cigar_gen(2, BAM_CDEL));
+    EXPECT_EQ(test_cigar[2], bam_cigar_gen(9, BAM_CMATCH));
 
     err = sam_read1(sam_fp, sam_hdr, aln);
     EXPECT_EQ(err, 0);
     lmap.lift_cigar(sam_hdr->target_name[aln->core.tid], aln);
     test_cigar = bam_get_cigar(aln);
     EXPECT_EQ(aln->core.n_cigar, 3);
-    EXPECT_EQ(test_cigar[0], bam_cigar_gen( 15, BAM_CMATCH));
-    EXPECT_EQ(test_cigar[1], bam_cigar_gen( 1, BAM_CDEL));
-    EXPECT_EQ(test_cigar[2], bam_cigar_gen( 5, BAM_CMATCH));
+    EXPECT_EQ(test_cigar[0], bam_cigar_gen(15, BAM_CMATCH));
+    EXPECT_EQ(test_cigar[1], bam_cigar_gen(1, BAM_CDEL));
+    EXPECT_EQ(test_cigar[2], bam_cigar_gen(5, BAM_CMATCH));
 
     sam_hdr_destroy(sam_hdr);
     sam_close(sam_fp);
@@ -245,18 +246,18 @@ TEST(LiftMap, DelInIndelBamCigarLift) {
     lmap.lift_cigar(sam_hdr->target_name[aln->core.tid], aln);
     test_cigar = bam_get_cigar(aln);
     EXPECT_EQ(aln->core.n_cigar, 3);
-    EXPECT_EQ(test_cigar[0], bam_cigar_gen( 7, BAM_CMATCH));
-    EXPECT_EQ(test_cigar[1], bam_cigar_gen( 15, BAM_CDEL));
-    EXPECT_EQ(test_cigar[2], bam_cigar_gen( 13, BAM_CMATCH));
+    EXPECT_EQ(test_cigar[0], bam_cigar_gen(7, BAM_CMATCH));
+    EXPECT_EQ(test_cigar[1], bam_cigar_gen(15, BAM_CDEL));
+    EXPECT_EQ(test_cigar[2], bam_cigar_gen(13, BAM_CMATCH));
 
     err = sam_read1(sam_fp, sam_hdr, aln);
     EXPECT_EQ(err, 0);
     lmap.lift_cigar(sam_hdr->target_name[aln->core.tid], aln);
     test_cigar = bam_get_cigar(aln);
     EXPECT_EQ(aln->core.n_cigar, 3);
-    EXPECT_EQ(test_cigar[0], bam_cigar_gen( 8, BAM_CMATCH));
-    EXPECT_EQ(test_cigar[1], bam_cigar_gen( 10, BAM_CDEL));
-    EXPECT_EQ(test_cigar[2], bam_cigar_gen( 8, BAM_CMATCH));
+    EXPECT_EQ(test_cigar[0], bam_cigar_gen(8, BAM_CMATCH));
+    EXPECT_EQ(test_cigar[1], bam_cigar_gen(10, BAM_CDEL));
+    EXPECT_EQ(test_cigar[2], bam_cigar_gen(8, BAM_CMATCH));
 
     sam_hdr_destroy(sam_hdr);
     sam_close(sam_fp);
@@ -276,23 +277,22 @@ TEST(LiftMap, SimpleSplicedBamCigarLift) {
     lmap.lift_cigar(sam_hdr->target_name[aln->core.tid], aln);
     test_cigar = bam_get_cigar(aln);
     EXPECT_EQ(aln->core.n_cigar, 3);
-    EXPECT_EQ(test_cigar[0], bam_cigar_gen( 7, BAM_CMATCH));
-    EXPECT_EQ(test_cigar[1], bam_cigar_gen( 15, BAM_CREF_SKIP));
-    EXPECT_EQ(test_cigar[2], bam_cigar_gen( 13, BAM_CMATCH));
+    EXPECT_EQ(test_cigar[0], bam_cigar_gen(7, BAM_CMATCH));
+    EXPECT_EQ(test_cigar[1], bam_cigar_gen(15, BAM_CREF_SKIP));
+    EXPECT_EQ(test_cigar[2], bam_cigar_gen(13, BAM_CMATCH));
 
     err = sam_read1(sam_fp, sam_hdr, aln);
     EXPECT_EQ(err, 0);
     lmap.lift_cigar(sam_hdr->target_name[aln->core.tid], aln);
     test_cigar = bam_get_cigar(aln);
     EXPECT_EQ(aln->core.n_cigar, 3);
-    EXPECT_EQ(test_cigar[0], bam_cigar_gen( 8, BAM_CMATCH));
-    EXPECT_EQ(test_cigar[1], bam_cigar_gen( 10, BAM_CREF_SKIP));
-    EXPECT_EQ(test_cigar[2], bam_cigar_gen( 8, BAM_CMATCH));
+    EXPECT_EQ(test_cigar[0], bam_cigar_gen(8, BAM_CMATCH));
+    EXPECT_EQ(test_cigar[1], bam_cigar_gen(10, BAM_CREF_SKIP));
+    EXPECT_EQ(test_cigar[2], bam_cigar_gen(8, BAM_CMATCH));
 
     sam_hdr_destroy(sam_hdr);
     sam_close(sam_fp);
 }
-
 
 TEST(HtslibTest, CigarOpType) {
     auto typeM = bam_cigar_type(BAM_CMATCH);
@@ -312,12 +312,11 @@ TEST(HtslibTest, CigarOpType) {
     EXPECT_EQ(typeI & 1, 1);
     EXPECT_EQ(typeI & 2, 0);
     EXPECT_EQ(typeI & 3, 1);
-    
+
     EXPECT_EQ(typeS & 1, 1);
     EXPECT_EQ(typeS & 2, 0);
     EXPECT_EQ(typeS & 3, 1);
 }
-
 
 TEST(UtilsTest, StrToSet) {
     std::set<std::string> s = LevioSamUtils::str_to_set("a,b", ",");
@@ -326,7 +325,6 @@ TEST(UtilsTest, StrToSet) {
     ASSERT_NE(s.find("b"), s.end());
     EXPECT_EQ(s.find("c"), s.end());
 }
-
 
 TEST(UtilsTest, UpdateFlagUnmap) {
     samFile* sam_fp = sam_open("simple_example.sam", "r");
@@ -348,7 +346,6 @@ TEST(UtilsTest, UpdateFlagUnmap) {
     sam_close(sam_fp);
 }
 
-
 TEST(UltimaGenomicsTest, UpdateFlags) {
     samFile* sam_fp = sam_open("ultima_small.sam", "r");
     sam_hdr_t* sam_hdr = sam_hdr_read(sam_fp);
@@ -360,17 +357,15 @@ TEST(UltimaGenomicsTest, UpdateFlags) {
     LevioSamUtils::update_ultima_genomics_tags(aln, true);
 
     // Tests the tp tag
-    uint8_t *tp_ptr = bam_aux_get(aln, "tp");
+    uint8_t* tp_ptr = bam_aux_get(aln, "tp");
     EXPECT_EQ(bam_auxB_len(tp_ptr), 10);
-    std::vector<int8_t> exp_tp_array {
-        -1,-1,0,1,-1,1,1,1,1,-1
-    };
+    std::vector<int8_t> exp_tp_array{-1, -1, 0, 1, -1, 1, 1, 1, 1, -1};
     for (uint32_t i = 0; i < 10; i++) {
-        EXPECT_EQ(bam_auxB2i(tp_ptr, i), exp_tp_array[i]); 
+        EXPECT_EQ(bam_auxB2i(tp_ptr, i), exp_tp_array[i]);
     }
 
     // Tests the t0 tag
-    uint8_t *t0_ptr = bam_aux_get(aln, "t0");
+    uint8_t* t0_ptr = bam_aux_get(aln, "t0");
     std::string t0_str = bam_aux2Z(t0_ptr);
     EXPECT_EQ(t0_str, "IIIII22222");
 
@@ -378,8 +373,40 @@ TEST(UltimaGenomicsTest, UpdateFlags) {
     sam_close(sam_fp);
 }
 
+TEST(ChainTest, test_get_mate_query_len_on_ref) {
+    std::string hdr_str =
+        "@HD	VN:1.0	SO:unsorted\n@SQ	SN:chr1	LN:248956422";
+    sam_hdr_t* sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
+    bam1_t* aln = bam_init1();
+    int err;
 
-int main(int argc, char **argv){
+    kstring_t str1;
+    std::string record1 =
+        "read1	81	chr1	145334831	33	6S10M	"
+        "=	1245932	0	ATTACATTCCATTCCA	~~~~~~~~~~~~~~~~	MC:Z:10M";
+    str1.s = (char*)record1.c_str();
+    str1.l = record1.length();
+    str1.m = kstr_get_m(str1.l);
+    err = sam_parse1(&str1, sam_hdr, aln);
+    EXPECT_EQ(err, 0);
+    EXPECT_EQ(LevioSamUtils::get_mate_query_len_on_ref(aln), 10);
+    bam_destroy1(aln);
+
+    aln = bam_init1();
+    kstring_t str2;
+    std::string record2 =
+        "read1	81	chr1	145334831	33	6S10M	"
+        "=	1245932	0	ATTACATTCCATTCCA	~~~~~~~~~~~~~~~~	MC:Z:6S5M1I4M";
+    str2.s = (char*)record2.c_str();
+    str2.l = record2.length();
+    str2.m = kstr_get_m(str2.l);
+    err = sam_parse1(&str2, sam_hdr, aln);
+    EXPECT_EQ(err, 0);
+    EXPECT_EQ(LevioSamUtils::get_mate_query_len_on_ref(aln), 9);
+    bam_destroy1(aln);
+}
+
+int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }

--- a/src/leviosam_utils.cpp
+++ b/src/leviosam_utils.cpp
@@ -12,10 +12,11 @@
 #include "leviosam_utils.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <regex>
 
 size_t kstr_get_m(size_t var) {
-    size_t lvar = (size_t)exp2(ceil(log2(var)));
+    size_t lvar = (size_t)std::exp2(std::ceil(std::log2(var)));
     return lvar;
 }
 

--- a/src/leviosam_utils.cpp
+++ b/src/leviosam_utils.cpp
@@ -14,6 +14,11 @@
 #include <algorithm>
 #include <regex>
 
+size_t kstr_get_m(size_t var) {
+    size_t lvar = (size_t)exp2(ceil(log2(var)));
+    return lvar;
+}
+
 namespace LevioSamUtils {
 
 void WriteDeferred::init(
@@ -238,7 +243,10 @@ void debug_print_cigar(uint32_t* cigar, size_t n_cigar) {
     std::cerr << "\n";
 }
 
-/* Remove MN:i and MD:z tags from an alignment (bam1_t) object */
+/** Removes the MN:i and MD:z tags from an alignment object.
+ *
+ * @param aln Alignment object.
+ */
 void remove_nm_md_tag(bam1_t* aln) {
     uint8_t* ptr = NULL;
     if ((ptr = bam_aux_get(aln, "MD")) != NULL) {
@@ -249,11 +257,36 @@ void remove_nm_md_tag(bam1_t* aln) {
     }
 }
 
-/* Return the read, reverse complemented if necessary
-   Adapted from: https://github.com/samtools/samtools/blob/develop/bam_fastq.c
-*/
-std::string get_read(const bam1_t* rec) {
-    int len = rec->core.l_qseq + 1;
+/** Gets the reference length of the mate segment.
+ *
+ * Leverages the "MC:Z" flag when available. If not, infers the query length.
+ *
+ * @param aln Alignment object.
+ * @return Reference length of the mate segment.
+ */
+hts_pos_t get_mate_query_len_on_ref(const bam1_t* aln) {
+    const bam1_core_t* c = &(aln->core);
+    uint8_t* ptr = NULL;
+    uint8_t* mc = bam_aux_get(aln, "MC");
+    if (mc) {
+        char* mate_cigar = bam_aux2Z(mc);
+        uint32_t* a_cigar = NULL;
+        size_t n_cigar = 0;
+        sam_parse_cigar(mate_cigar, NULL, &a_cigar, &n_cigar);
+        return bam_cigar2rlen(n_cigar, a_cigar);
+    } else {
+        return c->l_qseq;
+    }
+}
+
+/** Gets the forward read sequence.
+ *
+ * Adapted from: https://github.com/samtools/samtools/blob/develop/bam_fastq.c
+ *
+ * @param rec Alignment obejct.
+ * @return Read sequence string.
+ */
+std::string get_forward_read(const bam1_t* rec) {
     char* seq = (char*)bam_get_seq(rec);
     std::string read = "";
 
@@ -267,9 +300,14 @@ std::string get_read(const bam1_t* rec) {
     return read;
 }
 
-/* Return the read, regardless of reverse complement status */
-std::string get_read_as_is(const bam1_t* rec) {
-    int len = rec->core.l_qseq + 1;
+/** Gets the aligned read sequence.
+ *
+ * Use `get_forward_read()` if interested in the forward read sequence.
+ *
+ * @param rec Alignment obejct.
+ * @return Read sequence string.
+ */
+std::string get_read(const bam1_t* rec) {
     char* seq = (char*)bam_get_seq(rec);
     std::string read = "";
 
@@ -360,7 +398,7 @@ FastqRecord::~FastqRecord() {
 /* Write a FastqRecord object to a FASTQ file */
 int FastqRecord::write(ogzstream& out_fq, std::string name) {
     if (aln != NULL) {
-        seq_str = get_read(aln);
+        seq_str = get_forward_read(aln);
         std::string qual_seq("");
         uint8_t* qual = bam_get_qual(aln);
         if (qual[0] == 255)

--- a/src/leviosam_utils.hpp
+++ b/src/leviosam_utils.hpp
@@ -34,6 +34,8 @@
 const int8_t seq_comp_table[16] = {0, 8, 4, 12, 2, 10, 6, 14,
                                    1, 9, 5, 13, 3, 11, 7, 15};
 
+size_t kstr_get_m(size_t var);
+
 namespace LevioSamUtils {
 
 const std::vector<std::string> DEFER_OPT{"lifted", "mapq",      "clipped_frac",
@@ -88,8 +90,7 @@ class WriteDeferred {
               const BedUtils::Bed& b_defer_source,
               const BedUtils::Bed& b_defer_dest,
               const BedUtils::Bed& b_commit_source,
-              const BedUtils::Bed& b_commit_dest,
-              const float& b_isec_th);
+              const BedUtils::Bed& b_commit_dest, const float& b_isec_th);
 
     void print_info();
     void write_deferred_bam(bam1_t* aln, sam_hdr_t* hdr);
@@ -118,9 +119,15 @@ class WriteDeferred {
 
 void update_cigar(bam1_t* aln, std::vector<uint32_t>& new_cigar);
 void debug_print_cigar(uint32_t* cigar, size_t n_cigar);
+
+/** @brief Remove the MN:i and MD:z tags from an alignment object. */
 void remove_nm_md_tag(bam1_t* aln);
+
+/** @brief Gets the reference length of the mate segment. */
+hts_pos_t get_mate_query_len_on_ref(const bam1_t* aln);
+
+std::string get_forward_read(const bam1_t* rec);
 std::string get_read(const bam1_t* rec);
-std::string get_read_as_is(const bam1_t* rec);
 void update_flag_unmap(bam1_t* aln, const bool first_seg, const bool keep_mapq);
 
 std::vector<std::string> str_to_vector(const std::string str,
@@ -128,11 +135,11 @@ std::vector<std::string> str_to_vector(const std::string str,
 std::set<std::string> str_to_set(const std::string str,
                                  const std::string regex_str);
 
-/// @brief Returns true if a bam record is reversely lifted. 
+/** @brief Returns true if a bam record is reversely lifted. */
 bool is_reversedly_lifted(bam1_t* aln_orig, bam1_t* aln_lft);
 
-/// @brief Updates BAM tags specific to Ultima Genomics.
-void update_ultima_genomics_tags(bam1_t *aln, bool rev);
+/** @brief Updates BAM tags specific to Ultima Genomics. */
+void update_ultima_genomics_tags(bam1_t* aln, bool rev);
 
 int reverse_seq_and_qual(bam1_t* aln);
 sam_hdr_t* fai_to_hdr(std::string fai_fn, const sam_hdr_t* const hdr_orig);

--- a/workflow/README.md
+++ b/workflow/README.md
@@ -81,7 +81,7 @@ bash leviosam2.sh \
 For both short and long reads. Different parameters are recommended for each sequence type.
 
 - Supported aligners: [minimap2](https://github.com/lh3/minimap2), [winnowmap2](https://github.com/marbl/Winnowmap),
-[bwa mem](https://github.com/lh3/bwa) and [Bowtie 2](http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml) 
+[bwa mem](https://github.com/lh3/bwa) and [Bowtie 2](http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml)
 
 - `-g` sets the max allowed size of overlapping chain gaps of an alignment, `-H` is the max edit distance of an alignment (post-realignment) to be committed. Please adjust these parameters according to your long read platform and library preparation
 

--- a/workflow/leviosam2.py
+++ b/workflow/leviosam2.py
@@ -188,7 +188,6 @@ def parse_args() -> argparse.Namespace:
         "-O",
         "--out_format",
         type=str,
-        required=True,
         default="bam",
         choices=["bam", "sam", "cram"],
         help="Output file format.",


### PR DESCRIPTION
Previously, we inferred the mate reference length using the query length of a read. This can result in inconsistent lift-over results between a pair of reads. For example, if the soft clipped region of a paired-end read overlaps with a chain gap, leviosam2 used to ignore the gap for the main segment but assign the mate to be unliftable.

The `MC:Z` tag describes the CIGAR of the mate read in the paired-end mode. This PR uses the tag (when available) to calculate the mate starting and ending positions (wrt the reference) to increase the consistency of paired-end lift-over.

This feature is not compatible with htslib v1.11, which is pretty old. I also terminate the support of that version in this PR.