### PR TITLE
Corner case handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,17 @@ project(leviosam2 CXX C)
 
 set(PROJECT_URL "https://github.com/milkschen/leviosam2")
 set(PROJECT_DESCRIPTION "leviosam2")
-set(PROJECT_VER "0.4.2")
 set(CMAKE_CXX_STANDARD 14)
+
+# Get the latest abbreviated commit hash of the working branch
+execute_process(
+    COMMAND git log -1 --format=%h
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+    OUTPUT_VARIABLE GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+set(PROJECT_VER "0.4.2-${GIT_HASH}")
 
 find_library(HTS_LIB hts)
 if(NOT HTS_LIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,14 +172,15 @@ else()
 endif()
 
 
-file(GLOB LIB_SOURCES   src/reconcile.cpp src/lift_bed.cpp src/collate.cpp src/chain.cpp
-                        src/leviosam_utils.cpp src/bed.cpp src/lift_bed.cpp src/aln.cpp
-                        src/yaml.cpp
+file(GLOB LIB_SOURCES   src/reconcile.cpp src/lift_bed.cpp src/collate.cpp
+                        src/chain.cpp src/leviosam_utils.cpp src/bed.cpp
+                        src/lift_bed.cpp src/aln.cpp src/cigar.cpp src/yaml.cpp
                         src/ksw2_extd2_sse.c src/ksw2_extz2_sse.c src/ksw2_extz.c
                         src/bam_md.c src/bam_aux.c src/gzstream.C)
 file(GLOB LIB_HEADERS   src/leviosam.hpp
-                        src/reconcile.hpp src/lift_bed.hpp src/collate.hpp src/chain.hpp
-                        src/leviosam_utils.hpp src/bed.hpp src/lift_bed.hpp src/aln.hpp
+                        src/reconcile.hpp src/lift_bed.hpp src/collate.hpp
+                        src/chain.hpp src/leviosam_utils.hpp src/bed.hpp
+                        src/lift_bed.hpp src/aln.hpp src/cigar.hpp
                         src/yaml.hpp src/rapidyaml.hpp
                         src/ksw.h
                         src/bam.h src/IITree.h src/gzstream.h)
@@ -247,6 +248,17 @@ target_link_libraries(chain_test ${SDSL_LIB})
 target_link_libraries(chain_test gtest gtest_main)
 
 add_test(NAME chain_test COMMAND chain_test
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testdata
+)
+
+# cigar_test
+add_executable(cigar_test src/cigar_test.cpp)
+target_link_libraries(cigar_test lvsam)
+target_link_libraries(cigar_test ${HTS_LIB})
+target_link_libraries(cigar_test ${SDSL_LIB})
+target_link_libraries(cigar_test gtest gtest_main)
+
+add_test(NAME cigar_test COMMAND cigar_test
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testdata
 )
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,13 +7,13 @@ levioSAM2 supports a variety of methods for installation:
 - Singularity
 - CMake
 
-## Conda
+## Install levioSAM2 via Conda
 
 ```shell
 conda install -c conda-forge -c bioconda leviosam2
 ```
 
-## Docker
+## Use a levioSAM2 Docker image
 
 You can obtain a Docker image of the latest version from Docker hub:
 
@@ -21,47 +21,43 @@ You can obtain a Docker image of the latest version from Docker hub:
 docker pull naechyun/leviosam2:latest
 ```
 
-## Singularity
+## Use a levioSAM2 Singularity image
 
 ```shell
 singularity pull docker://naechyun/leviosam2:latest
 ```
 
-## CMake
+## Intall levioSAM2 from scratch using CMake
 
-### Prerequisites
+### Dependencies
 
-Make sure the following prerequisite libraries are installed on your system. 
+Make sure the following prerequisite libraries are installed on your system.
 
 - [htslib v1.12+ (tested up to v1.18)](https://github.com/samtools/htslib)
 - [sdsl-lite v2.1.1+](https://github.com/simongog/sdsl-lite/)
 
-Both libraries are available through coda:
+The dependent libraries can be installed through the following package manager options, or built from scratch:
 
 ```shell
+# Conda
 conda install -c conda-forge sdsl-lite
 conda install -c bioconda htslib
-```
 
-Another easy way to install these dependencies is to use your OS's existing package system:
+# Debian/Ubuntu
+apt-get install libhts-dev libsdsl-dev 
 
-```shell
-apt-get install libhts-dev libsdsl-dev # Debian/Ubuntu
-brew tap brewsci/bio; brew install htslib sdsl-lite # MacOS
-```
+# MacOS
+brew tap brewsci/bio
+brew install htslib sdsl-lite
 
-If using RedHat or Fedora, then you must install sdsl-lite manually. But you can install htslib through yum:
-
-```shell
+# RedHat or Fedora
 yum install htslib
+# sdsl-lite needs to be installed manually
 ```
-
-Or you can choose to install them manually by following the install instructions on their respective pages.
 
 ### CMake
 
-Once the prerequisite packages are installed and the locations of their installations are known, specify their locations
-to CMake by running the following commands:
+Command:
 
 ```shell
 mkdir build
@@ -73,21 +69,21 @@ make
 # make install DESTDIR=/path/to/install
 ```
 
-If you installed the dependencies manually, you might have to modify the `cmake` command to specify their library and
-include directory locations like so:
+If you installed the dependencies manually, you might need to provide the path
+of the dependent libraries to `cmake` by using the following command:
 
 ```shell
 cmake -D CMAKE_LIBRARY_PATH="/path/to/libsdsl/;/path/to/libhts/" \
       -D CMAKE_INCLUDE_PATH="/path/to/libsdsl/include/;/path/to/libhts/include/" ..
 ```
 
-## Test
+## Testing
 
 We provide an end-to-end test and a set of unit tests for levioSAM.
 
-- The end-to-end test can be run with `python leviosam-test.py`. This test includes running levioSAM on several test files in `testdata`. We also use `picard` to test if the lifted SAM files are valid.
+- The end-to-end test can be run with `python leviosam-test.py`. This test includes running levioSAM on several test files in `testdata`. We also use `picard` to validate the lifted results.
 
-- The unit test can be run `cd build; ctest` if you use cmake to build levioSAM; or `make gtest; cd testdata; ../gtest` if you use make to build levioSAM2.
+- The unit test can be run with the command `cd build; ctest --verbose`.
 
 ## ARM64
 

--- a/src/aln.cpp
+++ b/src/aln.cpp
@@ -11,7 +11,6 @@
  */
 #include "aln.hpp"
 
-
 namespace Aln {
 
 void AlnOpts::deserialize_realn(ryml::Tree realign_tree) {
@@ -22,8 +21,8 @@ void AlnOpts::deserialize_realn(ryml::Tree realign_tree) {
     if (realign_tree["alignment"].has_child("nm_threshold"))
         realign_tree["alignment"]["nm_threshold"] >> nm_threshold;
     if (realign_tree["alignment"]["a"].has_key())
-    if (realign_tree["alignment"].has_child("a"))
-        realign_tree["alignment"]["a"] >> a;
+        if (realign_tree["alignment"].has_child("a"))
+            realign_tree["alignment"]["a"] >> a;
     if (realign_tree["alignment"].has_child("b"))
         realign_tree["alignment"]["b"] >> b;
     if (realign_tree["alignment"].has_child("q"))
@@ -43,9 +42,11 @@ void AlnOpts::deserialize_realn(ryml::Tree realign_tree) {
 }
 
 void AlnOpts::print_parameters() {
-    std::cerr << "[I::aln::AlnOpts::print_parameters] engine = " << engine << "\n";
+    std::cerr << "[I::aln::AlnOpts::print_parameters] engine = " << engine
+              << "\n";
     std::cerr << "[I::aln::AlnOpts::print_parameters] flag = " << flag << "\n";
-    std::cerr << "[I::aln::AlnOpts::print_parameters] nm_threshold = " << nm_threshold << "\n";
+    std::cerr << "[I::aln::AlnOpts::print_parameters] nm_threshold = "
+              << nm_threshold << "\n";
     std::cerr << "[I::aln::AlnOpts::print_parameters] a = " << a << "\n";
     std::cerr << "[I::aln::AlnOpts::print_parameters] b = " << b << "\n";
     std::cerr << "[I::aln::AlnOpts::print_parameters] q = " << q << "\n";
@@ -53,29 +54,32 @@ void AlnOpts::print_parameters() {
     std::cerr << "[I::aln::AlnOpts::print_parameters] q2 = " << q2 << "\n";
     std::cerr << "[I::aln::AlnOpts::print_parameters] e2 = " << e2 << "\n";
     std::cerr << "[I::aln::AlnOpts::print_parameters] w = " << w << "\n";
-    std::cerr << "[I::aln::AlnOpts::print_parameters] zdrop = " << zdrop << "\n";
-    std::cerr << "[I::aln::AlnOpts::print_parameters] end_bonus = " << end_bonus << "\n";
+    std::cerr << "[I::aln::AlnOpts::print_parameters] zdrop = " << zdrop
+              << "\n";
+    std::cerr << "[I::aln::AlnOpts::print_parameters] end_bonus = " << end_bonus
+              << "\n";
 }
 
-int align_ksw2(
-    const char *tseq, const char *qseq, const AlnOpts& opt,
-    std::vector<uint32_t>& new_cigar, int& new_score
-) {
+int align_ksw2(const char* tseq, const char* qseq, const AlnOpts& opt,
+               std::vector<uint32_t>& new_cigar, int& new_score) {
     int i;
     int8_t a = opt.a, _b = opt.b;
-    int8_t b = _b < 0? _b : -_b; // a>0 and b<0
-    int8_t mat[25] = { a,b,b,b,0, b,a,b,b,0, b,b,a,b,0, b,b,b,a,0, 0,0,0,0,0 };
+    int8_t b = _b < 0 ? _b : -_b;  // a>0 and b<0
+    int8_t mat[25] = {a, b, b, b, 0, b, a, b, b, 0, b, b, a,
+                      b, 0, b, b, b, a, 0, 0, 0, 0, 0, 0};
     int tl = strlen(tseq), ql = strlen(qseq);
     uint8_t *ts, *qs, c[256];
     ksw_extz_t ez;
 
     memset(&ez, 0, sizeof(ksw_extz_t));
     memset(c, 4, 256);
-    c['A'] = c['a'] = 0; c['C'] = c['c'] = 1;
-    c['G'] = c['g'] = 2; c['T'] = c['t'] = 3; // build the encoding table
+    c['A'] = c['a'] = 0;
+    c['C'] = c['c'] = 1;
+    c['G'] = c['g'] = 2;
+    c['T'] = c['t'] = 3;  // build the encoding table
     ts = (uint8_t*)malloc(tl);
     qs = (uint8_t*)malloc(ql);
-    for (i = 0; i < tl; ++i) ts[i] = c[(uint8_t)tseq[i]]; // encode to 0/1/2/3
+    for (i = 0; i < tl; ++i) ts[i] = c[(uint8_t)tseq[i]];  // encode to 0/1/2/3
     for (i = 0; i < ql; ++i) qs[i] = c[(uint8_t)qseq[i]];
     if (opt.engine == "ksw_extd2_sse") {
         // void ksw_extd2_sse(
@@ -83,50 +87,49 @@ int align_ksw2(
         //      const uint8_t *target, int8_t m, const int8_t *mat,
         //      int8_t q, int8_t e, int8_t q2, int8_t e2, int w,
         //      int zdrop, int end_bonus, int flag, ksw_extz_t *ez)
-        ksw_extd2_sse(
-            0, ql, qs, tl, ts, 5, mat, opt.q, opt.e,
-            opt.q2, opt.e2, opt.w, opt.zdrop, opt.end_bonus,
-            opt.flag, &ez);
+        ksw_extd2_sse(0, ql, qs, tl, ts, 5, mat, opt.q, opt.e, opt.q2, opt.e2,
+                      opt.w, opt.zdrop, opt.end_bonus, opt.flag, &ez);
     } else if (opt.engine == "ksw_extz2_sse") {
         // void ksw_extz2_sse(
-        //     void *km, int qlen, const uint8_t *query, int tlen, 
+        //     void *km, int qlen, const uint8_t *query, int tlen,
         //     const uint8_t *target, int8_t m, const int8_t *mat,
         //     int8_t q, int8_t e, int w, int zdrop,
         //     int end_bonus, int flag, ksw_extz_t *ez)
-        ksw_extz2_sse(
-            0, ql, qs, tl, ts, 5, mat, opt.q, opt.e, opt.w,
-            opt.zdrop, opt.end_bonus, opt.flag, &ez);
+        ksw_extz2_sse(0, ql, qs, tl, ts, 5, mat, opt.q, opt.e, opt.w, opt.zdrop,
+                      opt.end_bonus, opt.flag, &ez);
     } else {
         // void ksw_extz(
         //     void *km, int qlen, const uint8_t *query, int tlen,
         //     const uint8_t *target, int8_t m, const int8_t *mat,
-        //     int8_t gapo, int8_t gape, int w, int zdrop, int flag, ksw_extz_t *ez)
-        ksw_extz(
-            0, ql, qs, tl, ts, 5, mat, opt.q, opt.e, opt.w,
-            opt.zdrop, opt.flag, &ez);
+        //     int8_t gapo, int8_t gape, int w, int zdrop, int flag, ksw_extz_t
+        //     *ez)
+        ksw_extz(0, ql, qs, tl, ts, 5, mat, opt.q, opt.e, opt.w, opt.zdrop,
+                 opt.flag, &ez);
     }
-    for (i = 0; i < ez.n_cigar; ++i) { // print CIGAR
+    for (i = 0; i < ez.n_cigar; ++i) {  // print CIGAR
         // printf("%d%c", ez.cigar[i]>>4, "MID"[ez.cigar[i]&0xf]);
-        chain::push_cigar(new_cigar, bam_cigar_oplen(ez.cigar[i]), bam_cigar_op(ez.cigar[i]), false);
+        Cigar::push_cigar(new_cigar, bam_cigar_oplen(ez.cigar[i]),
+                          bam_cigar_op(ez.cigar[i]), false);
     }
     if (new_cigar.size() > 0) {
         // If starts with INS, replace with SCLIP
-        if (bam_cigar_op(new_cigar[0]) == BAM_CINS){
+        if (bam_cigar_op(new_cigar[0]) == BAM_CINS) {
             auto len = bam_cigar_oplen(new_cigar[0]);
             new_cigar[0] = bam_cigar_gen(len, BAM_CSOFT_CLIP);
         }
         // If ends with INS, replace with SCLIP
         size_t last_idx = new_cigar.size() - 1;
-        if (bam_cigar_op(new_cigar[last_idx]) == BAM_CINS){
+        if (bam_cigar_op(new_cigar[last_idx]) == BAM_CINS) {
             auto len = bam_cigar_oplen(new_cigar[last_idx]);
             new_cigar[last_idx] = bam_cigar_gen(len, BAM_CSOFT_CLIP);
         }
     }
     // putchar('\n');
     new_score = ez.score;
-    free(ez.cigar); free(ts); free(qs);
+    free(ez.cigar);
+    free(ts);
+    free(qs);
     return ez.n_cigar;
 }
 
-
-};
+};  // namespace Aln

--- a/src/aln.hpp
+++ b/src/aln.hpp
@@ -12,15 +12,19 @@
 #define ALN_HPP
 
 #include <htslib/sam.h>
+
 #include <vector>
+
 #include "chain.hpp"
+#include "cigar.hpp"
 #include "ksw2.h"
+#include "leviosam_utils.hpp"
 #include "yaml.hpp"
 
 namespace Aln {
 
 class AlnOpts {
-public:
+   public:
     std::string engine = "ksw_extz";
     int flag = 0;
     int nm_threshold = 15;
@@ -31,11 +35,9 @@ public:
     void print_parameters();
 };
 
-int align_ksw2(
-    const char *tseq, const char *qseq, const AlnOpts& opt,
-    std::vector<uint32_t>& new_cigar, int& new_score
-);
+int align_ksw2(const char* tseq, const char* qseq, const AlnOpts& opt,
+               std::vector<uint32_t>& new_cigar, int& new_score);
 
-};
+};  // namespace Aln
 
 #endif

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -1054,6 +1054,7 @@ void ChainMap::lift_aln(bam1_t *aln, sam_hdr_t *hdr_source, sam_hdr_t *hdr_dest,
         lift_segment(aln, hdr_source, hdr_dest, true, dest_contig);
     if (!r1_liftable) {
         LevioSamUtils::update_flag_unmap(aln, true, keep_mapq);
+        Cigar::set_empty_cigar(aln);
     }
 
     size_t lift_status;

--- a/src/chain.hpp
+++ b/src/chain.hpp
@@ -137,14 +137,6 @@ class ChainMap {
                                       const int32_t eidx);
 };
 
-void push_cigar(std::vector<uint32_t> &cigar, uint32_t len, uint16_t op,
-                const bool no_reduct);
-void pop_cigar(std::vector<uint32_t> &cigar, uint32_t size);
-void sclip_cigar_front(uint32_t *cigar, const uint32_t &n_cigar, int len_clip,
-                       std::vector<uint32_t> &new_cigar, int &idx,
-                       int &query_offset);
-void sclip_cigar_back(std::vector<uint32_t> &new_cigar, int len_clip);
-
 };  // namespace chain
 
 #endif

--- a/src/chain.hpp
+++ b/src/chain.hpp
@@ -56,10 +56,8 @@ class ChainMap {
     ChainMap(std::string fname, int verbose, int allowed_intvl_gaps,
              LengthMap &lm);
     ChainMap(std::ifstream &in, int verbose, int allowed_intvl_gaps);
-    void init_bitvectors(
-        std::string source, int source_length,
-        std::unordered_map<std::string, sdsl::bit_vector> &start_bv_map,
-        std::unordered_map<std::string, sdsl::bit_vector> &end_bv_map);
+    void init_bitvectors(std::string source, int source_length,
+                         BitVectorMap &start_bv_map, BitVectorMap &end_bv_map);
     void sort_interval_map();
     void sort_intervals(std::string contig);
     void debug_print_interval_map();
@@ -105,8 +103,6 @@ class ChainMap {
                           int32_t &source_offset, int32_t &target_offset,
                           bool &strand, BitVectorMap &start_bv_map,
                           BitVectorMap &end_bv_map);
-
-    sam_hdr_t *bam_hdr_from_chainmap(samFile *sam_fp, sam_hdr_t *hdr_orig);
 
     // Checks the gap size between the intervals overlapped with an alignment.
     bool check_multi_intvl_legality(const std::string &source_contig,

--- a/src/chain.hpp
+++ b/src/chain.hpp
@@ -63,7 +63,7 @@ class ChainMap {
     void sort_interval_map();
     void sort_intervals(std::string contig);
     void debug_print_interval_map();
-    void debug_print_intervals(std::string contig);
+    void debug_print_intervals(std::string contig, const int n);
     bool interval_map_sanity_check();
     int get_start_rank(std::string contig, int pos);
     int get_end_rank(std::string contig, int pos);

--- a/src/chain_test.cpp
+++ b/src/chain_test.cpp
@@ -537,7 +537,7 @@ TEST(ChainTest, LiftExtendedCigarReverse3) {
     EXPECT_EQ(test_cigar[2], bam_cigar_gen(3, BAM_CMATCH));
 }
 
-TEST(ChainTest, test_check_multi_intvl_legality) {
+TEST(ChainTest, CheckMultiIntvlLegality) {
     std::vector<std::pair<std::string, int32_t>> lm;
     lm.push_back(std::make_pair("chr1", 248387328));
     chain::ChainMap cmap("small.chain", 0, 0, lm);
@@ -551,6 +551,39 @@ TEST(ChainTest, test_check_multi_intvl_legality) {
               true);
     EXPECT_EQ(cmap.check_multi_intvl_legality("chr1", "read1", sidx, eidx, 3),
               true);
+}
+
+TEST(ChainTest, UpdateIntervalIndexes) {
+    std::vector<std::pair<std::string, int32_t>> lm;
+    lm.push_back(std::make_pair("chr1", 248387328));
+    chain::ChainMap cmap("small.chain", 0, 0, lm);
+    // cmap.debug_print_intervals("chr1", 5);
+    int sidx = 0, eidx = 0;
+
+    // Straightforward test case.
+    EXPECT_EQ(cmap.update_interval_indexes("chr1", 674144, sidx, eidx), true);
+    EXPECT_EQ(sidx, 0);
+    EXPECT_EQ(eidx, 0);
+
+    // Contig not in the map.
+    EXPECT_EQ(cmap.update_interval_indexes("chr100", 0, sidx, eidx), false);
+    EXPECT_EQ(sidx, -1);
+    EXPECT_EQ(eidx, -1);
+
+    // Locus not covered by the chains.
+    EXPECT_EQ(cmap.update_interval_indexes("chr1", 674040, sidx, eidx), false);
+    EXPECT_EQ(sidx, -1);
+    EXPECT_EQ(eidx, 0);
+
+    // Invalid locus: outside chrom
+    EXPECT_EQ(cmap.update_interval_indexes("chr1", 1000000000, sidx, eidx),
+              false);
+    EXPECT_EQ(sidx, -1);
+    EXPECT_EQ(eidx, -1);
+
+    EXPECT_EQ(cmap.update_interval_indexes("chr1", 2680090, sidx, eidx), true);
+    EXPECT_EQ(sidx, 784);  // TODO: why not 785
+    EXPECT_EQ(eidx, 784);  // TODO: why not 785
 }
 
 int main(int argc, char **argv) {

--- a/src/chain_test.cpp
+++ b/src/chain_test.cpp
@@ -163,7 +163,7 @@ TEST(ChainTest, LiftCigar1) {
     lm.push_back(std::make_pair("chr1", 248387328));
     chain::ChainMap cmap("small.chain", 0, 0, lm);
     std::string hdr_str =
-        "@HD	VN:1.0	SO:unsorted\n@SQ	SN:chr1	LN:248956422";
+        "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
     sam_hdr_t *sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
     bam1_t *aln = bam_init1();
     int err;
@@ -173,8 +173,8 @@ TEST(ChainTest, LiftCigar1) {
     // CIGAR should not change
     kstring_t str;
     std::string record =
-        "unchanged	0	chr1	674850	42	7M13D13M	"
-        "*	0	0	CAGTTTGTAGTATCTGCAAG	~~~~~~~~~~~~~~~~~~~~";
+        "unchanged\t0\tchr1\t674850\t42\t7M13D13M\t"
+        "*\t0\t0\tCAGTTTGTAGTATCTGCAAG\t~~~~~~~~~~~~~~~~~~~~";
     str.s = (char *)record.c_str();
     str.l = record.length();
     str.m = kstr_get_m(str.l);
@@ -196,7 +196,7 @@ TEST(ChainTest, LiftCigar2) {
     lm.push_back(std::make_pair("chr1", 248387328));
     chain::ChainMap cmap("small.chain", 0, 0, lm);
     std::string hdr_str =
-        "@HD	VN:1.0	SO:unsorted\n@SQ	SN:chr1	LN:248956422";
+        "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
     sam_hdr_t *sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
     bam1_t *aln = bam_init1();
     int err;
@@ -206,8 +206,8 @@ TEST(ChainTest, LiftCigar2) {
     // Add 3 BAM_CSOFT_CLIPs in the beginning
     kstring_t str;
     std::string record =
-        "16M_3S13M	0	chr1	687455	42	16M	*	"
-        "0	0	ATTACATTCCATTCCA	~~~~~~~~~~~~~~~~";
+        "16M_3S13M\t0\tchr1\t687455\t42\t16M\t*\t"
+        "0\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~";
     str.s = (char *)record.c_str();
     str.l = record.length();
     str.m = kstr_get_m(str.l);
@@ -226,7 +226,7 @@ TEST(ChainTest, LiftCigar3) {
     lm.push_back(std::make_pair("chr1", 248387328));
     chain::ChainMap cmap("small.chain", 0, 0, lm);
     std::string hdr_str =
-        "@HD	VN:1.0	SO:unsorted\n@SQ	SN:chr1	LN:248956422";
+        "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
     sam_hdr_t *sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
     bam1_t *aln = bam_init1();
     int err;
@@ -236,8 +236,8 @@ TEST(ChainTest, LiftCigar3) {
     // Add 2 BAM_CINSs in the middle
     kstring_t str;
     std::string record =
-        "16M_10M2I4M	0	chr1	674141	42	16M	*	"
-        "0	0	ATTACATTCCATTCCA	~~~~~~~~~~~~~~~~";
+        "16M_10M2I4M\t0\tchr1\t674141\t42\t16M\t*\t"
+        "0\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~";
     str.s = (char *)record.c_str();
     str.l = record.length();
     str.m = kstr_get_m(str.l);
@@ -259,7 +259,7 @@ TEST(ChainTest, LiftCigar4) {
     lm.push_back(std::make_pair("chr1", 248387328));
     chain::ChainMap cmap("small.chain", 0, 0, lm);
     std::string hdr_str =
-        "@HD	VN:1.0	SO:unsorted\n@SQ	SN:chr1	LN:248956422";
+        "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
     sam_hdr_t *sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
     bam1_t *aln = bam_init1();
     int err;
@@ -269,8 +269,8 @@ TEST(ChainTest, LiftCigar4) {
     // Add 3 BAM_CDELs in the middle
     kstring_t str;
     std::string record =
-        "16M_10M3D6M	0	chr1	674820	42	16M	*	"
-        "0	0	ATTACATTCCATTCCA	~~~~~~~~~~~~~~~~";
+        "16M_10M3D6M\t0\tchr1\t674820\t42\t16M\t*\t"
+        "0\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~";
     str.s = (char *)record.c_str();
     str.l = record.length();
     str.m = kstr_get_m(str.l);
@@ -292,7 +292,7 @@ TEST(ChainTest, LiftCigar5) {
     lm.push_back(std::make_pair("chr1", 248387328));
     chain::ChainMap cmap("small.chain", 0, 0, lm);
     std::string hdr_str =
-        "@HD	VN:1.0	SO:unsorted\n@SQ	SN:chr1	LN:248956422";
+        "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
     sam_hdr_t *sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
     bam1_t *aln = bam_init1();
     int err;
@@ -302,8 +302,8 @@ TEST(ChainTest, LiftCigar5) {
     // Add 3 BAM_CSOFT_CLIPs in the beginning (secondary alignment)
     kstring_t str;
     std::string record =
-        "16M_3S13M	256	chr1	687455	42	"
-        "16M	*	0	0	*	*";
+        "16M_3S13M\t256\tchr1\t687455\t42\t"
+        "16M\t*\t0\t0\t*\t*";
     str.s = (char *)record.c_str();
     str.l = record.length();
     str.m = kstr_get_m(str.l);
@@ -324,7 +324,7 @@ TEST(ChainTest, LiftExtendedCigar1) {
     lm.push_back(std::make_pair("chr1", 248387328));
     chain::ChainMap cmap("small.chain", 0, 0, lm);
     std::string hdr_str =
-        "@HD	VN:1.0	SO:unsorted\n@SQ	SN:chr1	LN:248956422";
+        "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
     sam_hdr_t *sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
     bam1_t *aln = bam_init1();
     int err;
@@ -335,9 +335,9 @@ TEST(ChainTest, LiftExtendedCigar1) {
     // CIGAR should not change
     kstring_t str;
     std::string record =
-        "7=13D6=1X6=_7M13D13M	0	chr1	674850	"
-        "42	7=13D6=1X6=	*	0	0	"
-        "CAGTTTGTAGTATCTGCAAG	~~~~~~~~~~~~~~~~~~~~";
+        "7=13D6=1X6=_7M13D13M\t0\tchr1\t674850\t"
+        "42\t7=13D6=1X6=\t*\t0\t0\t"
+        "CAGTTTGTAGTATCTGCAAG\t~~~~~~~~~~~~~~~~~~~~";
     str.s = (char *)record.c_str();
     str.l = record.length();
     str.m = kstr_get_m(str.l);
@@ -359,7 +359,7 @@ TEST(ChainTest, LiftExtendedCigar2) {
     lm.push_back(std::make_pair("chr1", 248387328));
     chain::ChainMap cmap("small.chain", 0, 0, lm);
     std::string hdr_str =
-        "@HD	VN:1.0	SO:unsorted\n@SQ	SN:chr1	LN:248956422";
+        "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
     sam_hdr_t *sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
     bam1_t *aln = bam_init1();
     int err;
@@ -369,8 +369,8 @@ TEST(ChainTest, LiftExtendedCigar2) {
     // Add 3 BAM_CSOFT_CLIPs in the beginning
     kstring_t str;
     std::string record =
-        "10=1X5=_3S13M	0	chr1	687455	42	10=1X5=	*	"
-        "0	0	ATTACATTCCATTCCA	~~~~~~~~~~~~~~~~";
+        "10=1X5=_3S13M\t0\tchr1\t687455\t42\t10=1X5=\t*\t"
+        "0\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~";
     str.s = (char *)record.c_str();
     str.l = record.length();
     str.m = kstr_get_m(str.l);
@@ -389,7 +389,7 @@ TEST(ChainTest, LiftExtendedCigarReverse1) {
     lm.push_back(std::make_pair("chr1", 248387497));
     chain::ChainMap cmap("chr1_reversed_region.chain", 0, 0, lm);
     std::string hdr_str =
-        "@HD	VN:1.0	SO:unsorted\n@SQ	SN:chr1	LN:248956422";
+        "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
     sam_hdr_t *sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
     bam1_t *aln = bam_init1();
     int err;
@@ -400,8 +400,8 @@ TEST(ChainTest, LiftExtendedCigarReverse1) {
     // CIGAR should not change
     kstring_t str;
     std::string record =
-        "10=1X5=_16M	0	chr1	145302531	42	10=1X5=	"
-        "*	0	0	ATTACATTCCATTCCA	~~~~~~~~~~~~~~~~";
+        "10=1X5=_16M\t0\tchr1\t145302531\t42\t10=1X5=\t"
+        "*\t0\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~";
     str.s = (char *)record.c_str();
     str.l = record.length();
     str.m = kstr_get_m(str.l);
@@ -422,7 +422,7 @@ TEST(ChainTest, LiftExtendedCigarReverse2) {
     chain::ChainMap cmap("chr1_reversed_region.chain", 0, 0, lm);
     // chain::ChainMap cmap ("chr1_reversed_region.chain", 5, 0, lm);
     std::string hdr_str =
-        "@HD	VN:1.0	SO:unsorted\n@SQ	SN:chr1	LN:248956422";
+        "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
     sam_hdr_t *sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
     bam1_t *aln = bam_init1();
     int err;
@@ -433,9 +433,9 @@ TEST(ChainTest, LiftExtendedCigarReverse2) {
     // Reverse & 1-bp DEL
     kstring_t str;
     std::string record =
-        "10=1X5=_10M1D6M	0	chr1	145331505	42	"
-        "10=1X5=	"
-        "*	0	0	ATTACATTCCATTCCA	~~~~~~~~~~~~~~~~";
+        "10=1X5=_10M1D6M\t0\tchr1\t145331505\t42\t"
+        "10=1X5=\t"
+        "*\t0\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~";
     str.s = (char *)record.c_str();
     str.l = record.length();
     str.m = kstr_get_m(str.l);
@@ -457,7 +457,7 @@ TEST(ChainTest, LiftExtendedCigarReverse3) {
     lm.push_back(std::make_pair("chr1", 248387497));
     chain::ChainMap cmap("chr1_reversed_region.chain", 0, 0, lm);
     std::string hdr_str =
-        "@HD	VN:1.0	SO:unsorted\n@SQ	SN:chr1	LN:248956422";
+        "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
     sam_hdr_t *sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
     bam1_t *aln = bam_init1();
     int err;
@@ -468,8 +468,8 @@ TEST(ChainTest, LiftExtendedCigarReverse3) {
     // Replacing 6-bp MATCH with INS
     kstring_t str;
     std::string record =
-        "10=1X5=_7M6I3M	0	chr1	145334831	42	10=1X5=	"
-        "*	0	0	ATTACATTCCATTCCA	~~~~~~~~~~~~~~~~";
+        "10=1X5=_7M6I3M\t0\tchr1\t145334831\t42\t10=1X5=\t"
+        "*\t0\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~";
     str.s = (char *)record.c_str();
     str.l = record.length();
     str.m = kstr_get_m(str.l);

--- a/src/chain_test.cpp
+++ b/src/chain_test.cpp
@@ -158,57 +158,6 @@ TEST(ChainTest, LiftCigarCoreOneRun) {
     EXPECT_EQ(bam_cigar_op(new_cigar[2]), BAM_CMATCH);
 }
 
-TEST(ChainTest, PushCigar) {
-    std::vector<uint32_t> cigar1;
-    chain::push_cigar(cigar1, 2, BAM_CMATCH, false);
-    chain::push_cigar(cigar1, 1, BAM_CMATCH, false);
-    EXPECT_EQ(cigar1.size(), 1);
-    EXPECT_EQ(bam_cigar_oplen(cigar1.back()), 3);
-    EXPECT_EQ(bam_cigar_op(cigar1.back()), BAM_CMATCH);
-
-    std::vector<uint32_t> cigar2;
-    chain::push_cigar(cigar2, 1, BAM_CINS, false);
-    chain::push_cigar(cigar2, 1, BAM_CDEL, false);
-    EXPECT_EQ(cigar2.size(), 1);
-    EXPECT_EQ(bam_cigar_oplen(cigar2.back()), 1);
-    EXPECT_EQ(bam_cigar_op(cigar2.back()), BAM_CMATCH);
-}
-
-TEST(ChainTest, SClipCigarFront1) {
-    // 5M -> 3S2M
-    std::vector<uint32_t> cigar;
-    chain::push_cigar(cigar, 5, BAM_CMATCH, false);
-    std::vector<uint32_t> new_cigar;
-    int idx = 0, q = 0;
-    chain::sclip_cigar_front(&cigar[0], cigar.size(), 3, new_cigar, idx, q);
-    EXPECT_EQ(new_cigar.size(), 1);
-    EXPECT_EQ(bam_cigar_oplen(new_cigar[0]), 3);
-    EXPECT_EQ(bam_cigar_op(new_cigar[0]), BAM_CSOFT_CLIP);
-    EXPECT_EQ(idx, 0);
-    EXPECT_EQ(q, 3);
-}
-
-TEST(ChainTest, SClipCigarFront2) {
-    // 4S2M -> 5S1M
-    std::vector<uint32_t> cigar;
-    chain::push_cigar(cigar, 4, BAM_CSOFT_CLIP, false);
-    chain::push_cigar(cigar, 2, BAM_CMATCH, false);
-    std::vector<uint32_t> new_cigar;
-    int idx = 0, q = 0;
-    chain::sclip_cigar_front(&cigar[0], cigar.size(), 5, new_cigar, idx, q);
-    EXPECT_EQ(new_cigar.size(), 1);
-    EXPECT_EQ(bam_cigar_oplen(new_cigar[0]), 5);
-    EXPECT_EQ(bam_cigar_op(new_cigar[0]), BAM_CSOFT_CLIP);
-    EXPECT_EQ(idx, 1);
-    EXPECT_EQ(q, 5);
-}
-
-TEST(ChainTest, SClipCigarBack) {
-    std::vector<uint32_t> cigar1;
-    chain::push_cigar(cigar1, 5, BAM_CMATCH, false);
-    std::vector<uint32_t> new_cigar1;
-}
-
 TEST(ChainTest, LiftCigar1) {
     std::vector<std::pair<std::string, int32_t>> lm;
     lm.push_back(std::make_pair("chr1", 248387328));

--- a/src/cigar.cpp
+++ b/src/cigar.cpp
@@ -1,0 +1,220 @@
+/*
+ * cigar.cpp
+ *
+ * Cigar-related utilities.
+ *
+ * Author: Nae-Chyun Chen
+ * Dept. of Computer Science, Johns Hopkins University
+ *
+ * Distributed under the MIT license
+ * https://github.com/milkschen/leviosam2
+ */
+#include "cigar.hpp"
+
+namespace Cigar {
+/**
+ * Updates a cigar vector.
+ *
+ * It is similar to `cigar.push_back(bam_cigar_gen(len, op))`, and additionally
+ * performs CIGAR operator reduction, e.g. (1M2M -> 3M), (1D1I -> 1M)
+ *
+ * @param cigar The CIGAR object to be updated.
+ * @param len The length of the new CIGAR element.
+ * @param op The operator of the new CIGAR element.
+ * @param no_reduct Set to true to disable CIGAR operator reduction.
+ */
+void push_cigar(std::vector<uint32_t>& cigar, uint32_t len, uint16_t op,
+                const bool no_reduct = false) {
+    if (len == 0) return;
+    if (cigar.size() == 0 || no_reduct) {
+        cigar.push_back(bam_cigar_gen(len, op));
+        return;
+    }
+    auto back_op = bam_cigar_op(cigar.back());
+    auto back_type = bam_cigar_type(back_op);
+    auto back_len = bam_cigar_oplen(cigar.back());
+    auto op_type = bam_cigar_type(op);
+    // If operators are the same, merge
+    // We also merge S-I/I-S cases
+    // We don't merge N-D, H-P because they might mean differently
+    if (back_op == op || (back_type == 1 && op_type == 1)) {
+        len += back_len;
+        cigar.back() = bam_cigar_gen(len, back_op);
+        // Cancel out complementary operators
+    } else if ((back_type == 2 && op_type == 1) ||
+               (back_type == 1 && op_type == 2)) {
+        // For cases S-D, we ignore Ds, since deletions don't
+        // contribute to either the alignment or the position
+        // in soft-clipped regions.
+        if (back_op == BAM_CSOFT_CLIP) {
+            return;
+        }
+        if (len == back_len) {
+            cigar.pop_back();
+            push_cigar(cigar, len, BAM_CMATCH, false);
+        } else if (len > back_len) {
+            len -= back_len;
+            cigar.back() = bam_cigar_gen(back_len, BAM_CMATCH);
+            cigar.push_back(bam_cigar_gen(len, op));
+        } else {
+            back_len -= len;
+            cigar.back() = bam_cigar_gen(back_len, back_op);
+            cigar.push_back(bam_cigar_gen(len, BAM_CMATCH));
+        }
+    } else
+        cigar.push_back(bam_cigar_gen(len, op));
+}
+
+/* Pop `size` bases from a CIGAR (represented as a vector)
+ */
+void pop_cigar(std::vector<uint32_t>& cigar, uint32_t size) {
+    while (size > 0) {
+        auto cg = cigar.back();
+        cigar.pop_back();
+        auto cigar_op_len = bam_cigar_oplen(cg);
+        auto cigar_op = bam_cigar_op(cg);
+        // Check if the last operator consumes REF; if it doesn't, just pop it
+        if (bam_cigar_type(cigar_op) & 1) {
+            if (cigar_op_len > size) {
+                cigar_op_len -= size;
+                size = 0;
+                push_cigar(cigar, cigar_op_len, cigar_op, false);
+            } else if (cigar_op_len == size) {
+                size = 0;
+            } else {
+                size -= cigar_op_len;
+            }
+        }
+    }
+}
+
+void sclip_cigar_front(uint32_t* cigar, const uint32_t& n_cigar, int len_clip,
+                       std::vector<uint32_t>& new_cigar, int& idx,
+                       int& query_offset) {
+    if (len_clip == 0) return;
+
+    for (auto i = idx; i < n_cigar; i++) {
+        auto cigar_op_len = bam_cigar_oplen(cigar[i]);
+        auto cigar_op = bam_cigar_op(cigar[i]);
+        // Only replace bases that consume the QUERY with the SOFT_CLIP ("S")
+        // operator
+        if (bam_cigar_type(cigar_op) & 1) {
+            // If a CIGAR OP is longer than #clipped, append clipped bases to
+            // the updated CIGAR and truncate the original CIGAR for future
+            // usage.
+            if (cigar_op_len >= len_clip) {
+                cigar_op_len -= len_clip;
+                push_cigar(new_cigar, len_clip, BAM_CSOFT_CLIP, false);
+                query_offset += len_clip;
+                // Update `idx` so that we don't need to revisit
+                // previous CIGAR OPs.
+                if (cigar_op_len > 0) {
+                    cigar[i] = bam_cigar_gen(cigar_op_len, cigar_op);
+                    idx = i;
+                } else {
+                    idx = i + 1;
+                }
+                return;
+            } else {
+                push_cigar(new_cigar, cigar_op_len, BAM_CSOFT_CLIP, false);
+                query_offset += cigar_op_len;
+                len_clip -= cigar_op_len;
+            }
+        }
+    }
+}
+
+void sclip_cigar_back(std::vector<uint32_t>& cigar, int len_clip) {
+    if (len_clip == 0) return;
+
+    int remaining_lc = len_clip;
+    for (int i = cigar.size() - 1; i >= 0; i--) {
+        auto cigar_op_len = bam_cigar_oplen(cigar[i]);
+        auto cigar_op = bam_cigar_op(cigar[i]);
+        cigar.pop_back();
+        // Only replace bases that consume the QUERY with the SOFT_CLIP ("S")
+        // operator
+        if (bam_cigar_type(cigar_op) & 1) {
+            if (cigar_op_len >= remaining_lc) {
+                // If a CIGAR OP is longer than #clipped, append clipped bases
+                // to the updated CIGAR and truncate the original CIGAR.
+                cigar_op_len -= remaining_lc;
+                push_cigar(cigar, cigar_op_len, cigar_op, false);
+                push_cigar(cigar, len_clip, BAM_CSOFT_CLIP, false);
+                return;
+            } else if (cigar_op == BAM_CMATCH) {
+                // If a CIGAR OP is not long enough, shorten `remaining_lc`
+                // and proceed to an earlier OP
+                remaining_lc -= cigar_op_len;
+            } else if (cigar_op == BAM_CINS || cigar_op == BAM_CSOFT_CLIP) {
+                len_clip += cigar_op_len;
+            } else {
+                std::cerr
+                    << "[W::chain::sclip_cigar_back] Unexpected OP during "
+                       "back_clipping: "
+                    << cigar_op << "\n";
+            }
+        }
+    }
+}
+
+void update_cigar(bam1_t* aln, std::vector<uint32_t>& new_cigar) {
+    uint32_t* cigar = bam_get_cigar(aln);
+    // Adapted from samtools/sam.c
+    // https://github.com/samtools/htslib/blob/2264113e5df1946210828e45d29c605915bd3733/sam.c#L515
+    if (aln->core.n_cigar != new_cigar.size()) {
+        auto cigar_st = (uint8_t*)bam_get_cigar(aln) - aln->data;
+        auto fake_bytes = aln->core.n_cigar * 4;
+        aln->core.n_cigar = (uint32_t)new_cigar.size();
+        auto n_cigar4 = aln->core.n_cigar * 4;
+        auto orig_len = aln->l_data;
+        if (n_cigar4 > fake_bytes) {
+            // Check if we need to update `aln->m_data`.
+            //
+            // Adapted from htslib/sam_internal.h
+            // https://github.com/samtools/htslib/blob/31f0a76d338c9bf3a6893b71dd437ef5fcaaea0e/sam_internal.h#L48
+            auto new_m_data = (size_t)aln->l_data + n_cigar4 - fake_bytes;
+            kroundup32(new_m_data);
+            if (new_m_data > aln->m_data) {
+                auto new_data =
+                    static_cast<uint8_t*>(realloc(aln->data, new_m_data));
+                if (!new_data) {
+                    std::cerr << "[Error] Failed to expand a bam1_t struct for "
+                              << bam_get_qname(aln) << "\n";
+                    std::cerr << "This is likely due to out of memory\n";
+                    exit(1);
+                }
+                aln->data = new_data;
+                aln->m_data = new_m_data;
+                cigar = bam_get_cigar(aln);
+            }
+        }
+        // Update memory usage of data.
+        aln->l_data = aln->l_data - fake_bytes + n_cigar4;
+        // Move data to the correct place.
+        memmove(aln->data + cigar_st + n_cigar4,
+                aln->data + cigar_st + fake_bytes,
+                orig_len - (cigar_st + fake_bytes));
+        // If new n_cigar is greater, copy the real CIGAR to the right place.
+        // Skipped this if new n_cigar is smaller than the original value.
+        if (n_cigar4 > fake_bytes) {
+            memcpy(aln->data + cigar_st,
+                   aln->data + (n_cigar4 - fake_bytes) + 8, n_cigar4);
+        }
+        aln->core.n_cigar = new_cigar.size();
+    }
+    for (int i = 0; i < aln->core.n_cigar; i++) {
+        *(cigar + i) = new_cigar[i];
+    }
+}
+
+void debug_print_cigar(uint32_t* cigar, size_t n_cigar) {
+    for (int i = 0; i < n_cigar; i++) {
+        auto cigar_op_len = bam_cigar_oplen(cigar[i]);
+        auto cigar_op = bam_cigar_op(cigar[i]);
+        std::cerr << cigar_op_len << bam_cigar_opchr(cigar_op);
+    }
+    std::cerr << "\n";
+}
+
+}  // namespace Cigar

--- a/src/cigar.cpp
+++ b/src/cigar.cpp
@@ -18,16 +18,16 @@
  *
  * @param b A BAM object.
  * @param desired Number of bytes to trim.
- * @return 0 if successful; -1 if failed.
  */
-int _realloc_bam_data(bam1_t* b, size_t desired) {
+void _realloc_bam_data(bam1_t* b, size_t desired) {
     uint32_t new_m_data;
     uint8_t* new_data;
     new_m_data = desired;
     kroundup32(new_m_data);
     if (new_m_data < desired) {
         errno = ENOMEM;  // Not strictly true but we can't store the size
-        return -1;
+        throw std::runtime_error(
+            "Failed to realloc BAM data - cannot allocate memory");
     }
     if ((bam_get_mempolicy(b) & BAM_USER_OWNS_DATA) == 0) {
         new_data = static_cast<uint8_t*>(realloc(b->data, new_m_data));
@@ -39,10 +39,9 @@ int _realloc_bam_data(bam1_t* b, size_t desired) {
             bam_set_mempolicy(b, bam_get_mempolicy(b) & (~BAM_USER_OWNS_DATA));
         }
     }
-    if (!new_data) return -1;
+    if (!new_data) throw std::runtime_error("Failed to realloc BAM data");
     b->data = new_data;
     b->m_data = new_m_data;
-    return 0;
 }
 
 namespace Cigar {
@@ -202,9 +201,8 @@ void sclip_cigar_back(CigarVector& cigar_vec, int len_clip) {
  * Sets the cigar string of a BAM record to be empty ("*").
  *
  * @param aln A BAM object.
- * @return
  */
-int set_empty_cigar(bam1_t* aln) {
+void set_empty_cigar(bam1_t* aln) {
     uint32_t prev_n_cigar = aln->core.n_cigar;
     size_t new_m_data = (size_t)aln->l_data - prev_n_cigar * 4;
 
@@ -217,10 +215,9 @@ int set_empty_cigar(bam1_t* aln) {
     memmove(aln->data + aln->core.l_qname,
             aln->data + aln->core.l_qname + prev_n_cigar * 4,
             new_m_data - aln->core.l_qname);
-    int ret = _realloc_bam_data(aln, new_m_data);
+    _realloc_bam_data(aln, new_m_data);
     aln->core.n_cigar = 0;
     aln->l_data -= prev_n_cigar * 4;
-    return ret;
 }
 
 void update_cigar(bam1_t* aln, CigarVector& new_cigar_vec) {

--- a/src/cigar.hpp
+++ b/src/cigar.hpp
@@ -17,7 +17,7 @@
 #include <iostream>
 #include <vector>
 
-int _realloc_bam_data(bam1_t* b, size_t desired);
+void _realloc_bam_data(bam1_t* b, size_t desired);
 
 namespace Cigar {
 
@@ -30,7 +30,7 @@ void pop_cigar(CigarVector& cigar_vec, uint32_t size);
 void sclip_cigar_front(uint32_t* cigar, const uint32_t& n_cigar, int len_clip,
                        CigarVector& new_cigar_vec, int& idx, int& query_offset);
 void sclip_cigar_back(CigarVector& cigar_vec, int len_clip);
-int set_empty_cigar(bam1_t* aln);
+void set_empty_cigar(bam1_t* aln);
 void update_cigar(bam1_t* aln, CigarVector& new_cigar_vec);
 void debug_print_cigar(uint32_t* cigar, size_t n_cigar);
 

--- a/src/cigar.hpp
+++ b/src/cigar.hpp
@@ -1,0 +1,35 @@
+/*
+ * cigar.hpp
+ *
+ * Cigar-related utilities.
+ *
+ * Author: Nae-Chyun Chen
+ * Dept. of Computer Science, Johns Hopkins University
+ *
+ * Distributed under the MIT license
+ * https://github.com/milkschen/leviosam2
+ */
+#ifndef CIGAR_HPP
+#define CIGAR_HPP
+
+#include <htslib/sam.h>
+
+#include <iostream>
+#include <vector>
+
+namespace Cigar {
+
+void push_cigar(std::vector<uint32_t>& cigar, uint32_t len, uint16_t op,
+                const bool no_reduct);
+void pop_cigar(std::vector<uint32_t>& cigar, uint32_t size);
+void sclip_cigar_front(uint32_t* cigar, const uint32_t& n_cigar, int len_clip,
+                       std::vector<uint32_t>& new_cigar, int& idx,
+                       int& query_offset);
+void sclip_cigar_back(std::vector<uint32_t>& new_cigar, int len_clip);
+
+void update_cigar(bam1_t* aln, std::vector<uint32_t>& new_cigar);
+void debug_print_cigar(uint32_t* cigar, size_t n_cigar);
+
+}  // namespace Cigar
+
+#endif

--- a/src/cigar.hpp
+++ b/src/cigar.hpp
@@ -17,7 +17,7 @@
 #include <iostream>
 #include <vector>
 
-void _realloc_bam_data(bam1_t* b, size_t desired);
+#include "leviosam_utils.hpp"
 
 namespace Cigar {
 

--- a/src/cigar.hpp
+++ b/src/cigar.hpp
@@ -17,17 +17,21 @@
 #include <iostream>
 #include <vector>
 
+int _realloc_bam_data(bam1_t* b, size_t desired);
+
 namespace Cigar {
 
-void push_cigar(std::vector<uint32_t>& cigar, uint32_t len, uint16_t op,
-                const bool no_reduct);
-void pop_cigar(std::vector<uint32_t>& cigar, uint32_t size);
-void sclip_cigar_front(uint32_t* cigar, const uint32_t& n_cigar, int len_clip,
-                       std::vector<uint32_t>& new_cigar, int& idx,
-                       int& query_offset);
-void sclip_cigar_back(std::vector<uint32_t>& new_cigar, int len_clip);
+using CigarVector = std::vector<uint32_t>;
 
-void update_cigar(bam1_t* aln, std::vector<uint32_t>& new_cigar);
+/// Adds a cigar element to a cigar vector.
+void push_cigar(CigarVector& cigar_vec, uint32_t len, uint16_t op,
+                const bool no_reduce);
+void pop_cigar(CigarVector& cigar_vec, uint32_t size);
+void sclip_cigar_front(uint32_t* cigar, const uint32_t& n_cigar, int len_clip,
+                       CigarVector& new_cigar_vec, int& idx, int& query_offset);
+void sclip_cigar_back(CigarVector& cigar_vec, int len_clip);
+int set_empty_cigar(bam1_t* aln);
+void update_cigar(bam1_t* aln, CigarVector& new_cigar_vec);
 void debug_print_cigar(uint32_t* cigar, size_t n_cigar);
 
 }  // namespace Cigar

--- a/src/cigar_test.cpp
+++ b/src/cigar_test.cpp
@@ -67,33 +67,34 @@ TEST(CigarTest, SClipCigarBack) {
     Cigar::CigarVector new_cigar1;
 }
 
-// TEST(CigarTest, SetEmptyCigar) {
-//     std::string hdr_str = "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:10000";
-//     sam_hdr_t* sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
-//     bam1_t* aln = bam_init1();
+TEST(CigarTest, SetEmptyCigar) {
+    std::string hdr_str = "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:10000";
+    sam_hdr_t* sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
+    bam1_t* aln = bam_init1();
 
-//     std::string record1 =
-//         "read1\t81\tchr1\t100\t33\t6S10M\t"
-//         "=\t300\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~\tMC:Z:10M\tNM:i:0";
-//     kstring_t str1;
-//     str1.s = (char*)record1.c_str();
-//     str1.l = record1.length();
-//     str1.m = kstr_get_m(str1.l);
-//     EXPECT_GE(sam_parse1(&str1, sam_hdr, aln), 0);
+    std::string record1 =
+        "read1\t81\tchr1\t100\t33\t6S10M\t"
+        "=\t300\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~\tMC:Z:10M\tNM:i:0";
+    kstring_t str1;
+    str1.s = (char*)record1.c_str();
+    str1.l = record1.length();
+    str1.m = kstr_get_m(str1.l);
+    EXPECT_GE(sam_parse1(&str1, sam_hdr, aln), 0);
 
-//     EXPECT_GE(Cigar::set_empty_cigar(aln), 0);
-//     bam_destroy1(aln);
+    EXPECT_GE(Cigar::set_empty_cigar(aln), 0);
+    bam_destroy1(aln);
 
-//     record1 =
-//         "read2\t81\tchr1\t100\t33\t2S3M2I2M2D7M1H\t"
-//         "=\t300\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~\tMC:Z:10M\tNM:i:0";
-//     str1.s = (char*)record1.c_str();
-//     str1.l = record1.length();
-//     str1.m = kstr_get_m(str1.l);
-//     EXPECT_EQ(sam_parse1(&str1, sam_hdr, aln), 0);
-//     EXPECT_GE(Cigar::set_empty_cigar(aln), 0);
-//     bam_destroy1(aln);
-// }
+    aln = bam_init1();
+    record1 =
+        "read2\t81\tchr1\t100\t33\t2S3M2I2M2D7M1H\t"
+        "=\t300\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~\tMC:Z:10M\tNM:i:0";
+    str1.s = (char*)record1.c_str();
+    str1.l = record1.length();
+    str1.m = kstr_get_m(str1.l);
+    EXPECT_EQ(sam_parse1(&str1, sam_hdr, aln), 0);
+    EXPECT_GE(Cigar::set_empty_cigar(aln), 0);
+    bam_destroy1(aln);
+}
 
 TEST(CigarTest, UpdateCigar) {
     std::string hdr_str =

--- a/src/cigar_test.cpp
+++ b/src/cigar_test.cpp
@@ -11,22 +11,20 @@
  */
 #include "cigar.hpp"
 
-// #include <unistd.h>
-
 #include <iostream>
 
 #include "gtest/gtest.h"
-// #include "leviosam_utils.hpp"
+#include "leviosam_utils.hpp"
 
 TEST(CigarTest, PushCigar) {
-    std::vector<uint32_t> cigar1;
+    Cigar::CigarVector cigar1;
     Cigar::push_cigar(cigar1, 2, BAM_CMATCH, false);
     Cigar::push_cigar(cigar1, 1, BAM_CMATCH, false);
     EXPECT_EQ(cigar1.size(), 1);
     EXPECT_EQ(bam_cigar_oplen(cigar1.back()), 3);
     EXPECT_EQ(bam_cigar_op(cigar1.back()), BAM_CMATCH);
 
-    std::vector<uint32_t> cigar2;
+    Cigar::CigarVector cigar2;
     Cigar::push_cigar(cigar2, 1, BAM_CINS, false);
     Cigar::push_cigar(cigar2, 1, BAM_CDEL, false);
     EXPECT_EQ(cigar2.size(), 1);
@@ -36,12 +34,11 @@ TEST(CigarTest, PushCigar) {
 
 TEST(CigarTest, SClipCigarFront1) {
     // 5M -> 3S2M
-    std::vector<uint32_t> cigar;
+    Cigar::CigarVector cigar;
     Cigar::push_cigar(cigar, 5, BAM_CMATCH, false);
-    std::vector<uint32_t> new_cigar;
+    Cigar::CigarVector new_cigar;
     int idx = 0, q = 0;
-    Cigar::sclip_cigar_front(&cigar[0], cigar.size(), 3, new_cigar, idx,
-                                     q);
+    Cigar::sclip_cigar_front(&cigar[0], cigar.size(), 3, new_cigar, idx, q);
     EXPECT_EQ(new_cigar.size(), 1);
     EXPECT_EQ(bam_cigar_oplen(new_cigar[0]), 3);
     EXPECT_EQ(bam_cigar_op(new_cigar[0]), BAM_CSOFT_CLIP);
@@ -51,13 +48,12 @@ TEST(CigarTest, SClipCigarFront1) {
 
 TEST(CigarTest, SClipCigarFront2) {
     // 4S2M -> 5S1M
-    std::vector<uint32_t> cigar;
+    Cigar::CigarVector cigar;
     Cigar::push_cigar(cigar, 4, BAM_CSOFT_CLIP, false);
     Cigar::push_cigar(cigar, 2, BAM_CMATCH, false);
-    std::vector<uint32_t> new_cigar;
+    Cigar::CigarVector new_cigar;
     int idx = 0, q = 0;
-    Cigar::sclip_cigar_front(&cigar[0], cigar.size(), 5, new_cigar, idx,
-                                     q);
+    Cigar::sclip_cigar_front(&cigar[0], cigar.size(), 5, new_cigar, idx, q);
     EXPECT_EQ(new_cigar.size(), 1);
     EXPECT_EQ(bam_cigar_oplen(new_cigar[0]), 5);
     EXPECT_EQ(bam_cigar_op(new_cigar[0]), BAM_CSOFT_CLIP);
@@ -66,37 +62,62 @@ TEST(CigarTest, SClipCigarFront2) {
 }
 
 TEST(CigarTest, SClipCigarBack) {
-    std::vector<uint32_t> cigar1;
+    Cigar::CigarVector cigar1;
     Cigar::push_cigar(cigar1, 5, BAM_CMATCH, false);
-    std::vector<uint32_t> new_cigar1;
+    Cigar::CigarVector new_cigar1;
 }
 
-// TEST(UtilsTest, UpdateCigar) {
-//     std::string hdr_str =
-//         "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
+// TEST(CigarTest, SetEmptyCigar) {
+//     std::string hdr_str = "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:10000";
 //     sam_hdr_t* sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
 //     bam1_t* aln = bam_init1();
-//     int err;
 
-//     kstring_t str1;
 //     std::string record1 =
-//         "read1\t81\tchr1\t145334831\t33\t6S10M\t"
-//         "=\t1245932\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~\tMC:Z:10M";
+//         "read1\t81\tchr1\t100\t33\t6S10M\t"
+//         "=\t300\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~\tMC:Z:10M\tNM:i:0";
+//     kstring_t str1;
 //     str1.s = (char*)record1.c_str();
 //     str1.l = record1.length();
 //     str1.m = kstr_get_m(str1.l);
-//     err = sam_parse1(&str1, sam_hdr, aln);
-//     EXPECT_EQ(err, 0);
+//     EXPECT_GE(sam_parse1(&str1, sam_hdr, aln), 0);
 
-//     std::vector<uint32_t> new_cigar;
-//     for (int i = 0; i < aln->core.n_cigar; i++) {
-//         auto cigar_op_len = bam_cigar_oplen(cigar[i]);
-//         auto cigar_op = bam_cigar_op(cigar[i]);
-//         push_cigar(new_cigar, cigar_op_len, cigar_op, false);
-//     }
-//     EXPECT_EQ(LevioSamUtils::update_cigar(aln), "16M");
+//     EXPECT_GE(Cigar::set_empty_cigar(aln), 0);
+//     bam_destroy1(aln);
+
+//     record1 =
+//         "read2\t81\tchr1\t100\t33\t2S3M2I2M2D7M1H\t"
+//         "=\t300\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~\tMC:Z:10M\tNM:i:0";
+//     str1.s = (char*)record1.c_str();
+//     str1.l = record1.length();
+//     str1.m = kstr_get_m(str1.l);
+//     EXPECT_EQ(sam_parse1(&str1, sam_hdr, aln), 0);
+//     EXPECT_GE(Cigar::set_empty_cigar(aln), 0);
 //     bam_destroy1(aln);
 // }
+
+TEST(CigarTest, UpdateCigar) {
+    std::string hdr_str =
+        "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
+    sam_hdr_t* sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
+    bam1_t* aln = bam_init1();
+    int err;
+
+    kstring_t str1;
+    std::string record1 =
+        "read1\t81\tchr1\t145334831\t33\t6S10M\t"
+        "=\t1245932\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~\tMC:Z:10M";
+    str1.s = (char*)record1.c_str();
+    str1.l = record1.length();
+    str1.m = kstr_get_m(str1.l);
+    err = sam_parse1(&str1, sam_hdr, aln);
+    EXPECT_EQ(err, 0);
+
+    Cigar::CigarVector new_cigar{bam_cigar_gen(16, BAM_CMATCH)};
+    Cigar::update_cigar(aln, new_cigar);
+    EXPECT_EQ(aln->core.n_cigar, 1);
+    EXPECT_EQ(*bam_get_cigar(aln), bam_cigar_gen(16, BAM_CMATCH));
+    bam_destroy1(aln);
+}
 
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);

--- a/src/cigar_test.cpp
+++ b/src/cigar_test.cpp
@@ -81,9 +81,16 @@ TEST(CigarTest, SetEmptyCigar) {
     str1.m = kstr_get_m(str1.l);
     EXPECT_GE(sam_parse1(&str1, sam_hdr, aln), 0);
 
-    EXPECT_GE(Cigar::set_empty_cigar(aln), 0);
+    Cigar::set_empty_cigar(aln);
+    std::string seq = "ATTACATTCCATTCCA";
+    EXPECT_EQ(aln->core.n_cigar, 0);
+    // SEQ is after CIGAR, so lets check if SEQ looks good.
+    for (auto i = 0; i < aln->core.l_qseq; i++) {
+        EXPECT_EQ(seq_nt16_str[bam_seqi(bam_get_seq(aln), i)], seq[i]);
+    }
     bam_destroy1(aln);
 
+    // Second test case. The original CIGAR is more complicated.
     aln = bam_init1();
     record1 =
         "read2\t81\tchr1\t100\t33\t2S3M2I2M2D7M1H\t"
@@ -92,7 +99,11 @@ TEST(CigarTest, SetEmptyCigar) {
     str1.l = record1.length();
     str1.m = kstr_get_m(str1.l);
     EXPECT_EQ(sam_parse1(&str1, sam_hdr, aln), 0);
-    EXPECT_GE(Cigar::set_empty_cigar(aln), 0);
+    Cigar::set_empty_cigar(aln);
+    EXPECT_EQ(aln->core.n_cigar, 0);
+    for (auto i = 0; i < aln->core.l_qseq; i++) {
+        EXPECT_EQ(seq_nt16_str[bam_seqi(bam_get_seq(aln), i)], seq[i]);
+    }
     bam_destroy1(aln);
 }
 
@@ -101,7 +112,6 @@ TEST(CigarTest, UpdateCigar) {
         "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
     sam_hdr_t* sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
     bam1_t* aln = bam_init1();
-    int err;
 
     kstring_t str1;
     std::string record1 =
@@ -110,8 +120,7 @@ TEST(CigarTest, UpdateCigar) {
     str1.s = (char*)record1.c_str();
     str1.l = record1.length();
     str1.m = kstr_get_m(str1.l);
-    err = sam_parse1(&str1, sam_hdr, aln);
-    EXPECT_EQ(err, 0);
+    EXPECT_EQ(sam_parse1(&str1, sam_hdr, aln), 0);
 
     Cigar::CigarVector new_cigar{bam_cigar_gen(16, BAM_CMATCH)};
     Cigar::update_cigar(aln, new_cigar);

--- a/src/cigar_test.cpp
+++ b/src/cigar_test.cpp
@@ -1,0 +1,104 @@
+/*
+ * ciar_test.cpp
+ *
+ * Test cigar related utilities for levioSAM2
+ *
+ * Author: Nae-Chyun Chen
+ * Dept. of Computer Science, Johns Hopkins University
+ *
+ * Distributed under the MIT license
+ * https://github.com/milkschen/leviosam2
+ */
+#include "cigar.hpp"
+
+// #include <unistd.h>
+
+#include <iostream>
+
+#include "gtest/gtest.h"
+// #include "leviosam_utils.hpp"
+
+TEST(CigarTest, PushCigar) {
+    std::vector<uint32_t> cigar1;
+    Cigar::push_cigar(cigar1, 2, BAM_CMATCH, false);
+    Cigar::push_cigar(cigar1, 1, BAM_CMATCH, false);
+    EXPECT_EQ(cigar1.size(), 1);
+    EXPECT_EQ(bam_cigar_oplen(cigar1.back()), 3);
+    EXPECT_EQ(bam_cigar_op(cigar1.back()), BAM_CMATCH);
+
+    std::vector<uint32_t> cigar2;
+    Cigar::push_cigar(cigar2, 1, BAM_CINS, false);
+    Cigar::push_cigar(cigar2, 1, BAM_CDEL, false);
+    EXPECT_EQ(cigar2.size(), 1);
+    EXPECT_EQ(bam_cigar_oplen(cigar2.back()), 1);
+    EXPECT_EQ(bam_cigar_op(cigar2.back()), BAM_CMATCH);
+}
+
+TEST(CigarTest, SClipCigarFront1) {
+    // 5M -> 3S2M
+    std::vector<uint32_t> cigar;
+    Cigar::push_cigar(cigar, 5, BAM_CMATCH, false);
+    std::vector<uint32_t> new_cigar;
+    int idx = 0, q = 0;
+    Cigar::sclip_cigar_front(&cigar[0], cigar.size(), 3, new_cigar, idx,
+                                     q);
+    EXPECT_EQ(new_cigar.size(), 1);
+    EXPECT_EQ(bam_cigar_oplen(new_cigar[0]), 3);
+    EXPECT_EQ(bam_cigar_op(new_cigar[0]), BAM_CSOFT_CLIP);
+    EXPECT_EQ(idx, 0);
+    EXPECT_EQ(q, 3);
+}
+
+TEST(CigarTest, SClipCigarFront2) {
+    // 4S2M -> 5S1M
+    std::vector<uint32_t> cigar;
+    Cigar::push_cigar(cigar, 4, BAM_CSOFT_CLIP, false);
+    Cigar::push_cigar(cigar, 2, BAM_CMATCH, false);
+    std::vector<uint32_t> new_cigar;
+    int idx = 0, q = 0;
+    Cigar::sclip_cigar_front(&cigar[0], cigar.size(), 5, new_cigar, idx,
+                                     q);
+    EXPECT_EQ(new_cigar.size(), 1);
+    EXPECT_EQ(bam_cigar_oplen(new_cigar[0]), 5);
+    EXPECT_EQ(bam_cigar_op(new_cigar[0]), BAM_CSOFT_CLIP);
+    EXPECT_EQ(idx, 1);
+    EXPECT_EQ(q, 5);
+}
+
+TEST(CigarTest, SClipCigarBack) {
+    std::vector<uint32_t> cigar1;
+    Cigar::push_cigar(cigar1, 5, BAM_CMATCH, false);
+    std::vector<uint32_t> new_cigar1;
+}
+
+// TEST(UtilsTest, UpdateCigar) {
+//     std::string hdr_str =
+//         "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
+//     sam_hdr_t* sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
+//     bam1_t* aln = bam_init1();
+//     int err;
+
+//     kstring_t str1;
+//     std::string record1 =
+//         "read1\t81\tchr1\t145334831\t33\t6S10M\t"
+//         "=\t1245932\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~\tMC:Z:10M";
+//     str1.s = (char*)record1.c_str();
+//     str1.l = record1.length();
+//     str1.m = kstr_get_m(str1.l);
+//     err = sam_parse1(&str1, sam_hdr, aln);
+//     EXPECT_EQ(err, 0);
+
+//     std::vector<uint32_t> new_cigar;
+//     for (int i = 0; i < aln->core.n_cigar; i++) {
+//         auto cigar_op_len = bam_cigar_oplen(cigar[i]);
+//         auto cigar_op = bam_cigar_op(cigar[i]);
+//         push_cigar(new_cigar, cigar_op_len, cigar_op, false);
+//     }
+//     EXPECT_EQ(LevioSamUtils::update_cigar(aln), "16M");
+//     bam_destroy1(aln);
+// }
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/leviosam.cpp
+++ b/src/leviosam.cpp
@@ -228,7 +228,7 @@ void read_and_lift(T *lift_map, std::mutex *mutex_fread,
             int new_score = 0;
             if (Aln::align_ksw2(ref_seq.data(), q_seq.data(), args.aln_opts,
                                 new_cigar, new_score) > 0) {
-                LevioSamUtils::update_cigar(aln_vec[i], new_cigar);
+                Cigar::update_cigar(aln_vec[i], new_cigar);
                 // Redo fillmd after re-align
                 bam_fillmd1(aln_vec[i], ref.data(), args.md_flag, 1);
                 bam_aux_append(aln_vec[i], "LR", 'i', 4, (uint8_t *)&new_score);

--- a/src/leviosam.hpp
+++ b/src/leviosam.hpp
@@ -24,6 +24,7 @@
 
 #include "aln.hpp"
 #include "bed.hpp"
+#include "cigar.hpp"
 #include "chain.hpp"
 #include "leviosam_utils.hpp"
 #include "version.hpp"
@@ -374,7 +375,7 @@ class Lift {
             new_cigar.push_back(bam_cigar_gen(cigar_op_len[i], cigar_op[i]));
         }
 
-        LevioSamUtils::update_cigar(b, new_cigar);
+        Cigar::update_cigar(b, new_cigar);
     }
 
     // returns size of s1 sequence

--- a/src/leviosam_test.cpp
+++ b/src/leviosam_test.cpp
@@ -373,17 +373,17 @@ TEST(UltimaGenomicsTest, UpdateFlags) {
     sam_close(sam_fp);
 }
 
-TEST(ChainTest, test_get_mate_query_len_on_ref) {
+TEST(ChainTest, GetMateQueryLenOnRef) {
     std::string hdr_str =
-        "@HD	VN:1.0	SO:unsorted\n@SQ	SN:chr1	LN:248956422";
+        "@HD\tVN:1.0\tSO:unsorted\n@SQ\tSN:chr1\tLN:248956422";
     sam_hdr_t* sam_hdr = sam_hdr_parse(hdr_str.length(), &hdr_str[0]);
     bam1_t* aln = bam_init1();
     int err;
 
     kstring_t str1;
     std::string record1 =
-        "read1	81	chr1	145334831	33	6S10M	"
-        "=	1245932	0	ATTACATTCCATTCCA	~~~~~~~~~~~~~~~~	MC:Z:10M";
+        "read1\t81\tchr1\t145334831\t33\t6S10M\t"
+        "=\t1245932\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~\tMC:Z:10M";
     str1.s = (char*)record1.c_str();
     str1.l = record1.length();
     str1.m = kstr_get_m(str1.l);
@@ -395,8 +395,8 @@ TEST(ChainTest, test_get_mate_query_len_on_ref) {
     aln = bam_init1();
     kstring_t str2;
     std::string record2 =
-        "read1	81	chr1	145334831	33	6S10M	"
-        "=	1245932	0	ATTACATTCCATTCCA	~~~~~~~~~~~~~~~~	MC:Z:6S5M1I4M";
+        "read1\t81\tchr1\t145334831\t33\t6S10M\t"
+        "=\t1245932\t0\tATTACATTCCATTCCA\t~~~~~~~~~~~~~~~~\tMC:Z:6S5M1I4M";
     str2.s = (char*)record2.c_str();
     str2.l = record2.length();
     str2.m = kstr_get_m(str2.l);

--- a/src/leviosam_utils.cpp
+++ b/src/leviosam_utils.cpp
@@ -185,65 +185,6 @@ bool WriteDeferred::commit_aln_dest(const bam1_t* const aln) {
     return true;
 }
 
-void update_cigar(bam1_t* aln, std::vector<uint32_t>& new_cigar) {
-    uint32_t* cigar = bam_get_cigar(aln);
-    // Adapted from samtools/sam.c
-    // https://github.com/samtools/htslib/blob/2264113e5df1946210828e45d29c605915bd3733/sam.c#L515
-    if (aln->core.n_cigar != new_cigar.size()) {
-        auto cigar_st = (uint8_t*)bam_get_cigar(aln) - aln->data;
-        auto fake_bytes = aln->core.n_cigar * 4;
-        aln->core.n_cigar = (uint32_t)new_cigar.size();
-        auto n_cigar4 = aln->core.n_cigar * 4;
-        auto orig_len = aln->l_data;
-        if (n_cigar4 > fake_bytes) {
-            // Check if we need to update `aln->m_data`.
-            //
-            // Adapted from htslib/sam_internal.h
-            // https://github.com/samtools/htslib/blob/31f0a76d338c9bf3a6893b71dd437ef5fcaaea0e/sam_internal.h#L48
-            auto new_m_data = (size_t)aln->l_data + n_cigar4 - fake_bytes;
-            kroundup32(new_m_data);
-            if (new_m_data > aln->m_data) {
-                auto new_data =
-                    static_cast<uint8_t*>(realloc(aln->data, new_m_data));
-                if (!new_data) {
-                    std::cerr << "[Error] Failed to expand a bam1_t struct for "
-                              << bam_get_qname(aln) << "\n";
-                    std::cerr << "This is likely due to out of memory\n";
-                    exit(1);
-                }
-                aln->data = new_data;
-                aln->m_data = new_m_data;
-                cigar = bam_get_cigar(aln);
-            }
-        }
-        // Update memory usage of data.
-        aln->l_data = aln->l_data - fake_bytes + n_cigar4;
-        // Move data to the correct place.
-        memmove(aln->data + cigar_st + n_cigar4,
-                aln->data + cigar_st + fake_bytes,
-                orig_len - (cigar_st + fake_bytes));
-        // If new n_cigar is greater, copy the real CIGAR to the right place.
-        // Skipped this if new n_cigar is smaller than the original value.
-        if (n_cigar4 > fake_bytes) {
-            memcpy(aln->data + cigar_st,
-                   aln->data + (n_cigar4 - fake_bytes) + 8, n_cigar4);
-        }
-        aln->core.n_cigar = new_cigar.size();
-    }
-    for (int i = 0; i < aln->core.n_cigar; i++) {
-        *(cigar + i) = new_cigar[i];
-    }
-}
-
-void debug_print_cigar(uint32_t* cigar, size_t n_cigar) {
-    for (int i = 0; i < n_cigar; i++) {
-        auto cigar_op_len = bam_cigar_oplen(cigar[i]);
-        auto cigar_op = bam_cigar_op(cigar[i]);
-        std::cerr << cigar_op_len << bam_cigar_opchr(cigar_op);
-    }
-    std::cerr << "\n";
-}
-
 /** Removes the MN:i and MD:z tags from an alignment object.
  *
  * @param aln Alignment object.
@@ -318,12 +259,17 @@ std::string get_read(const bam1_t* rec) {
     return read;
 }
 
-/* Update SAM flag to set a record as an unmapped alignment
+/**
+ * Sets an alignment to unmapped.
  *   - Clear forward/reverse status.
  *   - If paired, changed to improper paired.
  *
- * We currenly set an unliftable read as unampped, and thus the
- * BAM_FUNMAP or BAM_FMUNMAP flags will be raised.
+ * An unliftable read is considered as unmapped. The BAM_FUNMAP or BAM_FMUNMAP
+ * flags are updated accordingly.
+ *
+ * @param aln
+ * @param first_set
+ * @param keep_mapq
  */
 void update_flag_unmap(bam1_t* aln, const bool first_seg,
                        const bool keep_mapq = false) {

--- a/src/leviosam_utils.hpp
+++ b/src/leviosam_utils.hpp
@@ -22,7 +22,6 @@
 #include <vector>
 
 #include "bed.hpp"
-#include "cigar.hpp"
 #include "gzstream.h"
 
 #define SPLIT_MIN_MAPQ 30
@@ -118,10 +117,13 @@ class WriteDeferred {
     float bed_isec_threshold = BED_ISEC_TH;
 };
 
-/** @brief Remove the MN:i and MD:z tags from an alignment object. */
+/// Removes the MN:i and MD:z tags from a BAM object.
 void remove_nm_md_tag(bam1_t* aln);
 
-/** @brief Gets the reference length of the mate segment. */
+/// Removes the MC:z tag from a BAM object.
+void remove_aux_tag(bam1_t* aln, const std::string tag);
+
+/// Gets the reference length of the mate segment.
 hts_pos_t get_mate_query_len_on_ref(const bam1_t* aln);
 
 std::string get_forward_read(const bam1_t* rec);
@@ -133,15 +135,17 @@ std::vector<std::string> str_to_vector(const std::string str,
 std::set<std::string> str_to_set(const std::string str,
                                  const std::string regex_str);
 
-/** @brief Returns true if a bam record is reversely lifted. */
+/// Returns true if a bam record is reversely lifted.
 bool is_reversedly_lifted(bam1_t* aln_orig, bam1_t* aln_lft);
 
-/** @brief Updates BAM tags specific to Ultima Genomics. */
+/// Updates BAM tags specific to Ultima Genomics.
 void update_ultima_genomics_tags(bam1_t* aln, bool rev);
 
 int reverse_seq_and_qual(bam1_t* aln);
 sam_hdr_t* fai_to_hdr(std::string fai_fn, const sam_hdr_t* const hdr_orig);
 std::vector<std::pair<std::string, int32_t>> fai_to_map(std::string fai_fn);
+void _realloc_bam_data(bam1_t* b, size_t desired);
+
 sam_hdr_t* lengthmap_to_hdr(std::vector<std::pair<std::string, int32_t>> lm,
                             const sam_hdr_t* const hdr_orig);
 

--- a/src/leviosam_utils.hpp
+++ b/src/leviosam_utils.hpp
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "bed.hpp"
+#include "cigar.hpp"
 #include "gzstream.h"
 
 #define SPLIT_MIN_MAPQ 30
@@ -116,9 +117,6 @@ class WriteDeferred {
         bed_commit_dest;
     float bed_isec_threshold = BED_ISEC_TH;
 };
-
-void update_cigar(bam1_t* aln, std::vector<uint32_t>& new_cigar);
-void debug_print_cigar(uint32_t* cigar, size_t n_cigar);
 
 /** @brief Remove the MN:i and MD:z tags from an alignment object. */
 void remove_nm_md_tag(bam1_t* aln);

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -1,3 +1,3 @@
 #ifndef VERSION
-#define VERSION "0.4.2"
+#define VERSION "0.4.2-02b4ab7"
 #endif


### PR DESCRIPTION
1. Some code organizing
2. Clears CIGAR and the `MC:z` tag for unmapped reads (first and mate respectively)
3. Handles a pos out of chromosome case