### PR TITLE
Consistency check between chain target length and FAI file when indexing

### DIFF
--- a/docker/update_docker.sh
+++ b/docker/update_docker.sh
@@ -7,8 +7,6 @@ if [[ -z ${VER} ]]; then
     exit
 fi
 
-exit
-
 # build the environment image
 cd env
 docker build --tag leviosam2_env .

--- a/src/chain.hpp
+++ b/src/chain.hpp
@@ -102,7 +102,8 @@ class ChainMap {
                           std::string &target, int32_t &source_len,
                           int32_t &source_offset, int32_t &target_offset,
                           bool &strand, BitVectorMap &start_bv_map,
-                          BitVectorMap &end_bv_map);
+                          BitVectorMap &end_bv_map,
+                          const LengthMap &length_map);
 
     // Checks the gap size between the intervals overlapped with an alignment.
     bool check_multi_intvl_legality(const std::string &source_contig,
@@ -129,6 +130,10 @@ class ChainMap {
                                                     const bam1_core_t *const c,
                                                     const int &start_sidx,
                                                     const int &end_sidx);
+
+    void validate_chain_target_chromosome(const std ::string &target,
+                                          const int32_t &target_len,
+                                          const LengthMap &length_map);
 
     // Debug functions
     void debug_print_interval_queries(const bool first_seg, const bool leftmost,

--- a/src/chain_test.cpp
+++ b/src/chain_test.cpp
@@ -49,12 +49,16 @@ TEST(ChainTest, ParseChainLineCornerZero) {
     int source_offset = 0, target_offset = 0, source_len = 0;
     bool current_ss = true;
     chain::ChainMap cmap;
+    chain::LengthMap lmap{std::make_pair("corner_zero_dest", 300)};
     cmap.parse_chain_line(hdr, source, target, source_len, source_offset,
-                          target_offset, current_ss, start_bv_map, end_bv_map);
+                          target_offset, current_ss, start_bv_map, end_bv_map,
+                          lmap);
     cmap.parse_chain_line(line1, source, target, source_len, source_offset,
-                          target_offset, current_ss, start_bv_map, end_bv_map);
+                          target_offset, current_ss, start_bv_map, end_bv_map,
+                          lmap);
     cmap.parse_chain_line(line2, source, target, source_len, source_offset,
-                          target_offset, current_ss, start_bv_map, end_bv_map);
+                          target_offset, current_ss, start_bv_map, end_bv_map,
+                          lmap);
 
     for (auto &i : start_bv_map) {
         EXPECT_EQ(i.first, "corner_zero");


### PR DESCRIPTION
Adds a validation function to check the consistency of target chromosome length and the input FAI file. If not consistent, the program exits.

This avoids a common user mistake to use an inverted chain.