### PR TITLE
Commit logic improvements

### DIFF
--- a/src/collate.cpp
+++ b/src/collate.cpp
@@ -243,13 +243,12 @@ int collate_run(int argc, char** argv) {
     int c;
     collate_opts args;
     args.cmd = LevioSamUtils::make_cmd(argc, argv);
-    static struct option long_options[] {
+    static struct option long_options[]{
         {"sam", required_argument, 0, 'a'},
-            {"deferred_sam", required_argument, 0, 'b'},
-            {"output", required_argument, 0, 'p'},
-            {"fastq", required_argument, 0, 'q'},
-            {"verbose", required_argument, 0, 'V'},
-    };
+        {"deferred_sam", required_argument, 0, 'b'},
+        {"output", required_argument, 0, 'p'},
+        {"fastq", required_argument, 0, 'q'},
+        {"verbose", required_argument, 0, 'V'}};
     int long_index = 0;
     while ((c = getopt_long(argc, argv, "ha:b:p:q:V:", long_options,
                             &long_index)) != -1) {

--- a/src/leviosam.cpp
+++ b/src/leviosam.cpp
@@ -477,12 +477,13 @@ void print_lift_help_msg() {
     std::cerr << "Inputs:  -C path   Path to an indexed ChainMap.\n";
     std::cerr << "Options: -a path   Path to the SAM/BAM/CRAM file "
                  "to be lifted. \n";
-    std::cerr << "                   Leave empty or set to \"-\" to read "
-                 "from stdin.\n";
+    std::cerr << "                   "
+                 "Leave empty or set to \"-\" to read from stdin.\n";
     std::cerr << "         -t INT    Number of threads used.\n"
-                 "                   If -t is not set, the value would "
-                 "be the sum of\n"
-                 "                   --hts_threads and --lift_threads. [1] \n";
+                 "                   "
+                 "If -t is not set, the value would be the sum of\n"
+                 "                   "
+                 "--hts_threads and --lift_threads. [1] \n";
     std::cerr << "         --lift_threads INT "
                  "Number of threads used for lifting reads. \n"
                  "                            "  // align
@@ -508,8 +509,7 @@ void print_lift_help_msg() {
     std::cerr << "         -T INT    "
                  "Chunk size for each thread. [256] \n"
                  "                   "  // align
-                 "Each thread queries <-T> reads, lifts, "
-                 "and writes.\n"
+                 "Each thread queries <-T> reads, lifts, and writes.\n"
                  "                   "  // align
                  "Setting a larger -T uses slightly more "
                  "memory but might benefit thread scaling.\n";
@@ -517,20 +517,27 @@ void print_lift_help_msg() {
     std::cerr << "         Commit/defer rule options:\n";
     std::cerr << "           -S string<:int/float> Key-value pair of "
                  "a split rule. We allow appending multiple `-S` options.\n";
-    std::cerr << "                     Options: mapq:<int>, "
-                 "aln_score:<int>, isize:<int>, hdist:<int>, "
-                 "clipped_frac:<float>, lifted. [none]\n";
-    std::cerr << "                       * mapq          INT   Min MAPQ to "
-                 "commit (pre-liftover). [30]\n";
-    std::cerr << "                       * aln_score     INT   Min AS:i "
-                 "(alignment score) to commit (pre-liftover). [100]\n";
-    std::cerr << "                       * isize         INT   Max TLEN/isize "
-                 "to commit (post-liftover). [1000]\n";
-    std::cerr << "                       * hdist         INT   Max NM:i "
-                 "(Edit distance) to commit (post-liftover). "
-                 "`-m` and `-f` must be set. [5]\n";
-    std::cerr << "                       * clipped_frac  FLOAT Max fraction of "
-                 "clipped to commit (post-liftover). [0.05]\n";
+    std::cerr << "                     Options: "
+                 "mapq:<int>, aln_score:<int>, isize:<int>, hdist:<int>, "
+                 "clipped_frac:<float>. lifted. [none]\n";
+    std::cerr << "                       * mapq          INT   "
+                 "Min MAPQ (pre-liftover) accepted for a committed read.\n";
+    std::cerr << "                       * aln_score     INT   "
+                 "Min AS:i (alignment score) (pre-liftover) accepted for a "
+                 "committed read.\n";
+    std::cerr << "                       * isize         INT   "
+                 "Max TLEN/isize (post-liftover) accepted for a committed "
+                 "read.\n";
+    std::cerr << "                       * hdist         INT   "
+                 "Max NM:i (Edit distance) (post-liftover) accepted for a "
+                 "committed read.\n"
+                 "                                             "
+                 "`-m` and `-f` must be set.\n";
+    std::cerr << "                       * clipped_frac  FLOAT "
+                 "Max fraction of clipped bases (post-liftover) accepted for a "
+                 "committed read.\n"
+                 "                                             "
+                 "A higher value results in fewer committed reads.\n";
     std::cerr << "           Example: `-S mapq:20 -S aln_score:20` commits "
                  "MQ>=20 and AS>=20 alignments.\n";
     std::cerr << "           -r string Path to a BED file (source "

--- a/src/leviosam.cpp
+++ b/src/leviosam.cpp
@@ -529,8 +529,8 @@ void print_lift_help_msg() {
     std::cerr << "                       * hdist         INT   Max NM:i "
                  "(Edit distance) to commit (post-liftover). "
                  "`-m` and `-f` must be set. [5]\n";
-    std::cerr << "                       * clipped_frac  FLOAT Min fraction of "
-                 "clipped to commit (post-liftover). [0.95]\n";
+    std::cerr << "                       * clipped_frac  FLOAT Max fraction of "
+                 "clipped to commit (post-liftover). [0.05]\n";
     std::cerr << "           Example: `-S mapq:20 -S aln_score:20` commits "
                  "MQ>=20 and AS>=20 alignments.\n";
     std::cerr << "           -r string Path to a BED file (source "

--- a/src/leviosam.cpp
+++ b/src/leviosam.cpp
@@ -30,7 +30,6 @@
 #include "yaml.hpp"
 
 KSEQ_INIT(gzFile, gzread);
-;
 
 /** Updates allocated threads given input args.
  *
@@ -528,7 +527,7 @@ void print_lift_help_msg() {
     std::cerr << "                       * isize         INT   Max TLEN/isize "
                  "to commit (post-liftover). [1000]\n";
     std::cerr << "                       * hdist         INT   Max NM:i "
-                 "(Hamming dist.) to commit (post-liftover). "
+                 "(Edit distance) to commit (post-liftover). "
                  "`-m` and `-f` must be set. [5]\n";
     std::cerr << "                       * clipped_frac  FLOAT Min fraction of "
                  "clipped to commit (post-liftover). [0.95]\n";

--- a/src/leviosam_utils.cpp
+++ b/src/leviosam_utils.cpp
@@ -209,12 +209,26 @@ bool WriteDeferred::commit_aln_dest(const bam1_t* const aln) {
         return true;
     }
     if (split_modes.find("clipped_frac") != split_modes.end()) {
-        if (1.0 - (rlen / c->l_qseq) > max_clipped_frac) return false;
+        if (get_bam_frac_clipped(aln) > max_clipped_frac) return false;
     }
     if (split_modes.find("hdist") != split_modes.end()) {
         if (bam_aux2i(bam_aux_get(aln, "NM")) > max_hdist) return false;
     }
     return true;
+}
+
+/** Calculates the fraction of clipped bases.
+ *
+ * Starts by calculating the fraction of unclipped bases: rlen / qlen. Then
+ * subtracts this from 1 to get the fraction of clipped bases.
+ *
+ * @param aln Alignment object.
+ * @return Fraction of clipped bases.
+ */
+float get_bam_frac_clipped(const bam1_t* aln) {
+    const bam1_core_t* c = &(aln->core);
+    auto rlen = bam_cigar2rlen(c->n_cigar, bam_get_cigar(aln));
+    return 1.0 - (float(rlen) / c->l_qseq);
 }
 
 /** Checks if a split rule is valid.

--- a/src/leviosam_utils.hpp
+++ b/src/leviosam_utils.hpp
@@ -26,7 +26,7 @@
 
 #define SPLIT_MIN_MAPQ 30
 #define SPLIT_MAX_ISIZE 1000
-#define SPLIT_MAX_CLIPPED_FRAC 0.95
+#define SPLIT_MAX_CLIPPED_FRAC 0.05
 #define SPLIT_MIN_AS 100
 #define SPLIT_MAX_NM 5
 #define BED_ISEC_TH 0
@@ -121,6 +121,8 @@ class WriteDeferred {
 bool check_split_rule(std::string rule);
 
 bool add_split_rule(SplitRules& split_rules, std::string s);
+
+float get_bam_frac_clipped(const bam1_t* aln);
 
 /// Removes the MN:i and MD:z tags from a BAM object.
 void remove_nm_md_tag(bam1_t* aln);

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -1,3 +1,3 @@
 #ifndef VERSION
-#define VERSION "0.4.2-6e96ec9"
+#define VERSION "0.4.2-89d3ab6"
 #endif

--- a/src/version.hpp
+++ b/src/version.hpp
@@ -1,3 +1,3 @@
 #ifndef VERSION
-#define VERSION "0.4.2-7721149"
+#define VERSION "0.4.2-6e96ec9"
 #endif

--- a/workflow/leviosam2.py
+++ b/workflow/leviosam2.py
@@ -133,7 +133,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--lift_commit_max_frac_clipped",
         type=float,
-        help="[lift] Min fraction of clipped bases to commit",
+        help=(
+            "[lift] Max fraction of clipped bases "
+            "(1- bam_cigar2rlen / seq_length) to commit; "
+            "when higher, a read is deferred."
+        ),
         default=None,
     )
     parser.add_argument(

--- a/workflow/leviosam2.sh
+++ b/workflow/leviosam2.sh
@@ -40,12 +40,12 @@ REALN_CONFIG=""
 
 # Default parameters for Bowtie 2
 ALN=bowtie2
-# `-q 10 -A -10 -H 5 -m 1000 -p 0.95`
-# FRAC_CLIPPED="-S clipped_frac:0.95"
+# `-q 10 -A -10 -H 5 -m 1000 -p 0.05`
+# FRAC_CLIPPED="-S clipped_frac:0.05"
 # ISIZE="-S isize:1000"
 
 # Default parameters for BWA-MEM
-# ALN=bwamem # `-q 30 -A 100 -H 5 -m 1000 -p 0.95`
+# ALN=bwamem # `-q 30 -A 100 -H 5 -m 1000 -p 0.05`
 
 function print_usage_and_exit {
     echo "Run full levioSAM2 pipeline for a SAM/BAM file"

--- a/workflow/workflow-test.py
+++ b/workflow/workflow-test.py
@@ -135,7 +135,7 @@ class Workflow(unittest.TestCase):
         new_workflow = copy.deepcopy(self.workflow)
         new_workflow.lift_commit_min_mapq = 30
         new_workflow.lift_commit_min_score = 100
-        new_workflow.lift_commit_max_frac_clipped = 0.95
+        new_workflow.lift_commit_max_frac_clipped = 0.05
         new_workflow.lift_commit_max_isize = 1000
         new_workflow.lift_commit_max_hdist = 5
         new_workflow.lift_max_gap = 20
@@ -148,7 +148,7 @@ class Workflow(unittest.TestCase):
             f"{self.args.leviosam2_exe} lift -C {self.args.leviosam2_index} "
             f"-O bam -a {self.args.input_bam} "
             f"-p {self.args.out_prefix} -t 4 -m -f {self.args.target_fasta} "
-            f"-S mapq:30 -S aln_score:100 -S clipped_frac:0.95 "
+            f"-S mapq:30 -S aln_score:100 -S clipped_frac:0.05 "
             f"-S isize:1000 -S hdist:5 -G 20 "
             f"-r commit/source.bed -D defer/target.bed "
             f"-x configs/ilmn.yaml "


### PR DESCRIPTION
* Fixes an incorrect default value (clipped_frac should be 0.05 instead of 0.95)
* Improves testing
* Handles a corner case in `commit_aln_dest()` where `-S aln_score` is set but the read does not have an `AS:i` tag