### PR TITLE
use store_true for --use_preset

### DIFF
--- a/workflow/README.md
+++ b/workflow/README.md
@@ -3,7 +3,8 @@
 ## Dependencies
 
 All dependent software is included in our Docker/Singularity container.
-Users of other installation approaches may install the dependencies using conda, pre-built binary, or building from source.
+Users of other installation approaches may install the dependencies using
+conda, pre-built binary, or building from source.
 
 - Aligner: [minimap2](https://github.com/lh3/minimap2)/[winnowmap2](https://github.com/marbl/Winnowmap)/[bwa mem](https://github.com/lh3/bwa)/[Bowtie 2](http://bowtie-bio.sourceforge.net/bowtie2/manual.shtml)
 - samtools, bgzip
@@ -24,7 +25,7 @@ python leviosam2.py \
     -fi bt2/grch38.fna \
     --sequence_type ilmn_pe \
     -a bowtie2 \
-    --use_preset True \
+    --use_preset \
     --lift_bed_commit_source suppress_annotations.bed \  # optional
     --lift_bed_defer_target defer_annotations.bed   # optional
 ```
@@ -56,7 +57,7 @@ python leviosam2.py \
     -fi bwa/grch38.fna \
     --sequence_type ilmn_pe \
     -a bwamem \
-    --use_preset True \
+    --use_preset \
     --lift_bed_commit_source suppress_annotations.bed \  # optional
     --lift_bed_defer_target defer_annotations.bed   # optional
 ```
@@ -96,7 +97,7 @@ python leviosam2.py \
     -f grch38.fna \
     --sequence_type pb_hifi \
     -a minimap2 \
-    --use_preset True \
+    --use_preset \
     --lift_realign_config ../configs/pacbio_all.yaml \
     --lift_bed_commit_source suppress_annotations.bed  # optional
 ```
@@ -126,7 +127,7 @@ python leviosam2.py \
     -f grch38.fna \
     --sequence_type ont \
     -a minimap2 \
-    --use_preset True \
+    --use_preset \
     --lift_realign_config ../configs/ont_all.yaml \
     --lift_bed_commit_source suppress_annotations.bed  # optional
 ```

--- a/workflow/leviosam2.py
+++ b/workflow/leviosam2.py
@@ -231,8 +231,7 @@ def parse_args() -> argparse.Namespace:
     # )
     parser.add_argument(
         "--use_preset",
-        type=bool,
-        default=True,
+        action="store_true",
         help="Use default workflow parameters",
     )
     parser.add_argument(


### PR DESCRIPTION
There was no way to set `--use_preset` to `False` with the previous logic. This PR changes the argparse argument to fix it.

**Impact**

This change affects users currently using `--use_preset=True`. But it is fairly straightforward to troubleshoot. The workflow README is also updated to reflect the change.