### PR TITLE
Improve index/lift correctness coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,5 +302,13 @@ add_test(NAME reconcile_test COMMAND reconcile_test
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/testdata
 )
 
+add_test(NAME cli_index_lift_test
+    COMMAND ${CMAKE_COMMAND}
+        "-DLEVIOSAM2=$<TARGET_FILE:leviosam2>"
+        "-DTEST_TMP_DIR=${CMAKE_CURRENT_BINARY_DIR}/cli-index-lift-test"
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/cli_index_lift_test.cmake
+)
+set_tests_properties(cli_index_lift_test PROPERTIES TIMEOUT 30)
+
 INSTALL(TARGETS leviosam2 DESTINATION bin)
 INSTALL(FILES src/leviosam.hpp DESTINATION include)

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -152,19 +152,27 @@ ChainMap::ChainMap(std::string fname, int verbose, int allowed_intvl_gaps,
     std::string line;
     BitVectorMap start_bv_map;
     BitVectorMap end_bv_map;
-    if (chain_f.is_open()) {
-        std::string source;
-        std::string target;
-        int32_t source_offset = 0;
-        int32_t target_offset = 0;
-        int source_len = 0;
-        bool current_ss = true;
-        while (getline(chain_f, line)) {
-            parse_chain_line(line, source, target, source_len, source_offset,
-                             target_offset, current_ss, start_bv_map,
-                             end_bv_map, lm);
-        }
-        chain_f.close();
+    if (!chain_f.is_open()) {
+        std::cerr << "[E::chain::build] Cannot open chain file " << fname
+                  << "\n";
+        exit(1);
+    }
+    std::string source;
+    std::string target;
+    int32_t source_offset = 0;
+    int32_t target_offset = 0;
+    int source_len = 0;
+    bool current_ss = true;
+    while (getline(chain_f, line)) {
+        parse_chain_line(line, source, target, source_len, source_offset,
+                         target_offset, current_ss, start_bv_map,
+                         end_bv_map, lm);
+    }
+    chain_f.close();
+    if (interval_map.empty()) {
+        std::cerr << "[E::chain::build] No chain intervals found in " << fname
+                  << "\n";
+        exit(1);
     }
     // biv_vector to sd_vector
     for (auto &it : start_bv_map) {
@@ -511,7 +519,6 @@ int ChainMap::lift_cigar(const std::string &contig, bam1_t *aln) {
     auto end_sidx = get_start_rank(contig, pos_end) - 1;
     auto end_eidx = get_end_rank(contig, pos_end) - 1;
 
-    auto next_intvl = interval_map[contig][start_sidx + 1];
     int32_t num_sclip_start =
         get_num_clipped(c->pos, true, contig, start_sidx, start_eidx);
     int32_t num_sclip_end =
@@ -638,6 +645,11 @@ void ChainMap::lift_cigar_core_one_run(
                 return;
             }
         }
+        if (break_points.empty()) {
+            Cigar::push_cigar(new_cigar, cigar_op_len, cigar_op, false);
+            query_offset += cigar_op_len;
+            return;
+        }
         auto next_bp = std::get<0>(break_points.front());
         auto next_q_offset = query_offset + cigar_op_len;
         if (verbose >= VERBOSE_DEV) {
@@ -652,7 +664,7 @@ void ChainMap::lift_cigar_core_one_run(
         }
         // Push the current CIGAR OP and advance if have not reached the next
         // breakpoint or there are no remaining breakpoints
-        if (next_q_offset <= next_bp || break_points.size() == 0) {
+        if (next_q_offset <= next_bp) {
             Cigar::push_cigar(new_cigar, cigar_op_len, cigar_op, false);
             query_offset += cigar_op_len;
             // Split one CIGAR chunk into two parts and insert lift-over bases
@@ -714,13 +726,9 @@ void ChainMap::lift_cigar_core_one_run(
                     query_offset -= diff;
                 }
 
-                // Popping an empty queue results in undefined behaviors
-                if (break_points.size() == 0) {
-                    break;
-                } else {
-                    break_points.pop();
-                    next_bp = std::get<0>(break_points.front());
-                }
+                break_points.pop();
+                if (break_points.empty()) break;
+                next_bp = std::get<0>(break_points.front());
             }
             if (second_half_len < 0) {
                 // tmp_gap = -second_half_len;
@@ -1493,7 +1501,7 @@ std::queue<std::tuple<int32_t, int32_t>> ChainMap::get_bp(
     const std::string &contig, const bam1_core_t *const c,
     const int &start_sidx, const int &end_sidx) {
     std::queue<std::tuple<int32_t, int32_t>> break_points;
-    for (auto i = start_sidx; i <= end_sidx; i++) {
+    for (auto i = start_sidx; i < end_sidx; i++) {
         int bp = interval_map[contig][i].source_end - c->pos;
         int diff;
         // forward strand
@@ -1571,8 +1579,16 @@ bool ChainMap::check_multi_intvl_legality(const std::string &source_contig,
         std::cerr << "[D::chain::check_multi_intvl_legality] next_sintvl: ";
         next_sintvl.debug_print_interval();
     }
-    // Check the gap size between the intervals
-    int chain_gap = std::abs(next_sintvl.offset - start_sintvl.offset);
+    auto transform_offset = [](const Interval &intvl) -> int64_t {
+        if (intvl.strand) return intvl.offset;
+        return static_cast<int64_t>(intvl.offset) + intvl.source_start +
+               intvl.source_end;
+    };
+    // Check the gap size between the intervals. Reverse intervals need the
+    // full coordinate transform rather than their raw stored offset.
+    int64_t chain_gap =
+        std::abs(transform_offset(next_sintvl) -
+                 transform_offset(start_sintvl));
     if (chain_gap > allowed_intvl_gaps) {
         if (verbose >= VERBOSE_INFO) {
             std::cerr
@@ -1607,8 +1623,8 @@ bool ChainMap::check_multi_intvl_legality(const std::string &source_contig,
             }
             return false;
         }
-        if (std::abs(interval_map[source_contig][j + 1].offset -
-                     interval_map[source_contig][j].offset) >
+        if (std::abs(transform_offset(interval_map[source_contig][j + 1]) -
+                     transform_offset(interval_map[source_contig][j])) >
             allowed_intvl_gaps) {
             if (verbose >= VERBOSE_INFO) {
                 std::cerr << "[I::chain::check_multi_intvl_legality] Set `"

--- a/src/chain_test.cpp
+++ b/src/chain_test.cpp
@@ -13,6 +13,7 @@
 
 #include <unistd.h>
 
+#include <fstream>
 #include <iostream>
 
 #include "gtest/gtest.h"
@@ -160,6 +161,47 @@ TEST(ChainTest, LiftCigarCoreOneRun) {
     EXPECT_EQ(bam_cigar_op(new_cigar[1]), BAM_CINS);
     EXPECT_EQ(bam_cigar_oplen(new_cigar[2]), 32);
     EXPECT_EQ(bam_cigar_op(new_cigar[2]), BAM_CMATCH);
+}
+
+TEST(ChainTest, LiftCigarCoreOneRunWithNoBreakpoints) {
+    std::vector<uint32_t> new_cigar;
+    int query_offset = 0;
+    int tmp_gap = 0;
+    std::queue<std::tuple<int32_t, int32_t>> break_points;
+    chain::ChainMap cmap;
+
+    cmap.lift_cigar_core_one_run(new_cigar, break_points, 10, BAM_CMATCH, 10,
+                                 tmp_gap, query_offset);
+
+    ASSERT_EQ(new_cigar.size(), 1);
+    EXPECT_EQ(bam_cigar_oplen(new_cigar[0]), 10);
+    EXPECT_EQ(bam_cigar_op(new_cigar[0]), BAM_CMATCH);
+    EXPECT_EQ(query_offset, 10);
+    EXPECT_EQ(tmp_gap, 0);
+}
+
+TEST(ChainTest, SerializationRoundTrip) {
+    std::vector<std::pair<std::string, int32_t>> lm;
+    lm.push_back(std::make_pair("chr1", 248387328));
+    chain::ChainMap original("small.chain", 0, 0, lm);
+
+    char path[] = "/tmp/leviosam2-chain-roundtrip-XXXXXX";
+    int fd = mkstemp(path);
+    ASSERT_GE(fd, 0);
+    close(fd);
+    {
+        std::ofstream out(path, std::ios::binary | std::ios::trunc);
+        ASSERT_TRUE(out.good());
+        original.serialize(out);
+    }
+    std::ifstream in(path, std::ios::binary);
+    ASSERT_TRUE(in.good());
+    chain::ChainMap restored(in, 0, 0);
+    unlink(path);
+
+    EXPECT_EQ(restored.length_map, original.length_map);
+    EXPECT_EQ(restored.lift_contig("chr1", 674047), "chr1");
+    EXPECT_EQ(restored.lift_pos("chr1", 674047, 0, true), 100272);
 }
 
 TEST(ChainTest, LiftCigar1) {

--- a/src/cigar.cpp
+++ b/src/cigar.cpp
@@ -224,12 +224,6 @@ void update_cigar(bam1_t* aln, CigarVector& new_cigar_vec) {
         memmove(aln->data + cigar_st + n_cigar4,
                 aln->data + cigar_st + fake_bytes,
                 orig_len - (cigar_st + fake_bytes));
-        // If new n_cigar is greater, copy the real CIGAR to the right place.
-        // Skipped this if new n_cigar is smaller than the original value.
-        if (n_cigar4 > fake_bytes) {
-            memcpy(aln->data + cigar_st,
-                   aln->data + (n_cigar4 - fake_bytes) + 8, n_cigar4);
-        }
         aln->core.n_cigar = new_cigar_vec.size();
     }
     for (int i = 0; i < aln->core.n_cigar; i++) {

--- a/src/cigar_test.cpp
+++ b/src/cigar_test.cpp
@@ -127,6 +127,43 @@ TEST(CigarTest, UpdateCigar) {
     EXPECT_EQ(aln->core.n_cigar, 1);
     EXPECT_EQ(*bam_get_cigar(aln), bam_cigar_gen(16, BAM_CMATCH));
     bam_destroy1(aln);
+
+    // Expanding the CIGAR must preserve the sequence and auxiliary data that
+    // follow it in bam1_t::data.
+    aln = bam_init1();
+    std::string record2 =
+        "read2\t0\tchr1\t100\t33\t10M\t*\t0\t0\tACGTACGTAC\t"
+        "IIIIIIIIII\tMC:Z:10M\tNM:i:1";
+    kstring_t str2;
+    str2.s = (char*)record2.c_str();
+    str2.l = record2.length();
+    str2.m = kstr_get_m(str2.l);
+    ASSERT_EQ(sam_parse1(&str2, sam_hdr, aln), 0);
+
+    Cigar::CigarVector expanded_cigar{bam_cigar_gen(5, BAM_CMATCH),
+                                      bam_cigar_gen(1, BAM_CINS),
+                                      bam_cigar_gen(4, BAM_CMATCH)};
+    Cigar::update_cigar(aln, expanded_cigar);
+
+    ASSERT_EQ(aln->core.n_cigar, 3);
+    uint32_t* cigar = bam_get_cigar(aln);
+    EXPECT_EQ(cigar[0], expanded_cigar[0]);
+    EXPECT_EQ(cigar[1], expanded_cigar[1]);
+    EXPECT_EQ(cigar[2], expanded_cigar[2]);
+    std::string expected_seq = "ACGTACGTAC";
+    for (int i = 0; i < aln->core.l_qseq; ++i) {
+        EXPECT_EQ(seq_nt16_str[bam_seqi(bam_get_seq(aln), i)],
+                  expected_seq[i]);
+        EXPECT_EQ(bam_get_qual(aln)[i], 40);
+    }
+    uint8_t* mc = bam_aux_get(aln, "MC");
+    uint8_t* nm = bam_aux_get(aln, "NM");
+    ASSERT_NE(mc, nullptr);
+    ASSERT_NE(nm, nullptr);
+    EXPECT_STREQ(bam_aux2Z(mc), "10M");
+    EXPECT_EQ(bam_aux2i(nm), 1);
+    bam_destroy1(aln);
+    sam_hdr_destroy(sam_hdr);
 }
 
 int main(int argc, char** argv) {

--- a/src/leviosam.cpp
+++ b/src/leviosam.cpp
@@ -19,9 +19,13 @@
 #include <zlib.h>
 
 #include <algorithm>
+#include <cerrno>
+#include <climits>
+#include <cmath>
+#include <cstdlib>
 #include <ctime>
-#include <vector>
 #include <fstream>
+#include <vector>
 
 #include "aln.hpp"
 #include "collate.hpp"
@@ -31,6 +35,32 @@
 #include "yaml.hpp"
 
 KSEQ_INIT(gzFile, gzread);
+
+static int parse_int_option(const char *option, const char *value, int minimum) {
+    char *end = nullptr;
+    errno = 0;
+    long parsed = std::strtol(value, &end, 10);
+    if (errno == ERANGE || end == value || *end != '\0' || parsed < minimum ||
+        parsed > INT_MAX) {
+        std::cerr << "[E::main] Invalid value for " << option << ": " << value
+                  << "\n";
+        exit(1);
+    }
+    return static_cast<int>(parsed);
+}
+
+static float parse_float_option(const char *option, const char *value) {
+    char *end = nullptr;
+    errno = 0;
+    float parsed = std::strtof(value, &end);
+    if (errno == ERANGE || end == value || *end != '\0' ||
+        !std::isfinite(parsed)) {
+        std::cerr << "[E::main] Invalid value for " << option << ": " << value
+                  << "\n";
+        exit(1);
+    }
+    return parsed;
+}
 
 /** Updates allocated threads given input args.
  *
@@ -46,9 +76,18 @@ KSEQ_INIT(gzFile, gzread);
  * @return 0 if successful, 1 if not.
  */
 uint8_t update_thread_allocation(lift_opts &args) {
+    if (args.threads < 1) {
+        std::cerr << "[E::update_thread_allocation] --threads must be >= 1.\n";
+        return 1;
+    }
     if (args.lift_threads < 1) {
         std::cerr << "[E::update_thread_allocation] --lift_threads must "
-                     ">= 1.\n";
+                     "be >= 1.\n";
+        return 1;
+    }
+    if (args.hts_threads < 0) {
+        std::cerr << "[E::update_thread_allocation] --hts_threads must be >= "
+                     "0.\n";
         return 1;
     }
     if (args.threads > DEFAULT_NUM_THREADS) {
@@ -77,10 +116,15 @@ uint8_t update_thread_allocation(lift_opts &args) {
 NameMap parse_name_map(const char *fname) {
     NameMap names;
     FILE *fp = fopen(fname, "r");
+    if (fp == nullptr) {
+        std::cerr << "[E::parse_name_map] Cannot open name map " << fname
+                  << "\n";
+        exit(1);
+    }
     char n1[255];
     char n2[255];
     int x;
-    while ((x = fscanf(fp, "%[^\t]\t%[^\n]\n", n1, n2)) != EOF) {
+    while ((x = fscanf(fp, "%254[^\t]\t%254[^\n]\n", n1, n2)) != EOF) {
         if (x <= 0) {
             std::cerr << "[E::parse_name_map] Failed to read name map from "
                       << fname << "\n";
@@ -113,7 +157,18 @@ void serialize_run(lift_opts args) {
                                             args.haplotype, args.name_map,
                                             args.length_map));
         std::ofstream o(fn_index, std::ios::binary);
+        if (!o) {
+            std::cerr << "[E::serialize_run] Cannot open output " << fn_index
+                      << "\n";
+            exit(1);
+        }
         l.serialize(o);
+        o.flush();
+        if (!o) {
+            std::cerr << "[E::serialize_run] Failed writing " << fn_index
+                      << "\n";
+            exit(1);
+        }
         std::cerr << "[I::serialize_run] levioSAM VcfMap saved to " << fn_index
                   << "\n";
         // ChainMap
@@ -122,7 +177,18 @@ void serialize_run(lift_opts args) {
         chain::ChainMap cfp(args.chain_fname, args.verbose,
                             args.allowed_cigar_changes, args.length_map);
         std::ofstream o(fn_index, std::ios::binary);
+        if (!o) {
+            std::cerr << "[E::serialize_run] Cannot open output " << fn_index
+                      << "\n";
+            exit(1);
+        }
         size_t bytes = cfp.serialize(o);
+        o.flush();
+        if (!o) {
+            std::cerr << "[E::serialize_run] Failed writing " << fn_index
+                      << "\n";
+            exit(1);
+        }
         cfp.log_index_size(bytes);
         std::cerr << "[I::serialize_run] levioSAM ChainMap saved to "
                   << fn_index << "\n";
@@ -158,6 +224,11 @@ void read_and_lift(T *lift_map, std::mutex *mutex_fread,
             std::lock_guard<std::mutex> g(*mutex_fread);
             for (int i = 0; i < args.chunk_size; i++) {
                 read = sam_read1(sam_fp, hdr_source, aln_vec[i]);
+                if (read < -1) {
+                    std::cerr << "[E::read_and_lift] Failed to read alignment "
+                                 "input\n";
+                    exit(1);
+                }
                 if (read < 0) {
                     num_actual_reads = i;
                     break;
@@ -307,6 +378,11 @@ void lift_run(lift_opts args) {
             std::cerr << "[I::lift_run] Loading levioSAM 2 index...";
             std::ifstream in(args.chainmap_fname, std::ios::binary);
             std::ifstream fs(args.chainmap_fname, std::ios::binary | std::ios::ate);
+            if (!in || !fs || fs.tellg() <= 0) {
+                std::cerr << "[E::lift_run] Cannot open ChainMap index "
+                          << args.chainmap_fname << "\n";
+                exit(1);
+            }
             chain_bytes = fs.tellg();
             return chain::ChainMap(in, args.verbose,
                                    args.allowed_cigar_changes);
@@ -328,6 +404,11 @@ void lift_run(lift_opts args) {
         if (args.lift_fname != "") {
             std::cerr << "[I::lift_run] Loading levioSAM index...";
             std::ifstream in(args.lift_fname, std::ios::binary);
+            if (!in) {
+                std::cerr << "[E::lift_run] Cannot open levioSAM index "
+                          << args.lift_fname << "\n";
+                exit(1);
+            }
             return lift::LiftMap(in);
             // if "-l" not specified, then create a levioSAM
         } else if (args.vcf_fname != "") {
@@ -361,11 +442,14 @@ void lift_run(lift_opts args) {
                           ? sam_open("-", "r")
                           : sam_open(args.sam_fname.data(), "r");
 
-    // Gets extra threads to decompress HTS files when requested
-    if (args.hts_threads > 0) hts_set_threads(sam_fp, args.hts_threads);
-
     if (!sam_fp) {
         std::cerr << "[E::lift_run] Invalid alignment input\n";
+        exit(1);
+    }
+    // Gets extra threads to decompress HTS files when requested
+    if (args.hts_threads > 0 &&
+        hts_set_threads(sam_fp, args.hts_threads) != 0) {
+        std::cerr << "[E::lift_run] Failed to configure input HTS threads\n";
         exit(1);
     }
     std::string out_mode = (args.out_format == "sam") ? "w" : "wb";
@@ -382,7 +466,11 @@ void lift_run(lift_opts args) {
         exit(1);
     }
     // Gets extra threads to compress HTS files when requested
-    if (args.hts_threads > 0) hts_set_threads(out_sam_fp, args.hts_threads);
+    if (args.hts_threads > 0 &&
+        hts_set_threads(out_sam_fp, args.hts_threads) != 0) {
+        std::cerr << "[E::lift_run] Failed to configure output HTS threads\n";
+        exit(1);
+    }
 
     sam_hdr_t *hdr_orig = sam_hdr_read(sam_fp);
     if (!hdr_orig) {
@@ -394,7 +482,10 @@ void lift_run(lift_opts args) {
                    NULL);
     sam_hdr_add_pg(hdr_orig, "leviosam2", "VN", VERSION, "CL", args.cmd.data(),
                    NULL);
-    auto write_hdr = sam_hdr_write(out_sam_fp, hdr);
+    if (sam_hdr_write(out_sam_fp, hdr) < 0) {
+        std::cerr << "[E::lift_run] Failed to write output header\n";
+        exit(1);
+    }
 
     if (args.md_flag) {
         if (args.ref_name == "") {
@@ -610,7 +701,6 @@ int main(int argc, char **argv) {
     } else if (!strcmp(argv[optind], "reconcile")) {
         return reconcile_run(argc, argv);
     }
-
     double start_cputime = std::clock();
     auto start_walltime = std::chrono::system_clock::now();
 
@@ -667,7 +757,8 @@ int main(int argc, char **argv) {
                 args.sam_fname = optarg;
                 break;
             case 'B':
-                args.bed_isec_threshold = std::stof(optarg);
+                args.bed_isec_threshold = parse_float_option("-B", optarg);
+                break;
             case 'c':
                 args.chain_fname = optarg;
                 break;
@@ -691,7 +782,7 @@ int main(int argc, char **argv) {
                 args.haplotype = optarg;
                 break;
             case 'G':
-                args.allowed_cigar_changes = atoi(optarg);
+                args.allowed_cigar_changes = parse_int_option("-G", optarg, 0);
                 break;
             case 'l':
                 args.lift_fname = optarg;
@@ -722,13 +813,13 @@ int main(int argc, char **argv) {
                 }
                 break;
             case 't':
-                args.threads = atoi(optarg);
+                args.threads = parse_int_option("-t", optarg, 1);
                 break;
             case 'T':
-                args.chunk_size = atoi(optarg);
+                args.chunk_size = parse_int_option("-T", optarg, 1);
                 break;
             case 'V':
-                args.verbose = atoi(optarg);
+                args.verbose = parse_int_option("-V", optarg, 0);
                 break;
             case 'v':
                 args.vcf_fname = optarg;
@@ -746,10 +837,12 @@ int main(int argc, char **argv) {
                 args.keep_mapq = true;
                 break;
             case OPT_LIFT_THREADS:
-                args.lift_threads = atoi(optarg);
+                args.lift_threads =
+                    parse_int_option("--lift_threads", optarg, 1);
                 break;
             case OPT_HTS_THREADS:
-                args.hts_threads = atoi(optarg);
+                args.hts_threads =
+                    parse_int_option("--hts_threads", optarg, 0);
                 break;
             default:
                 std::cerr << "[E::main] Invalid flag value " << c << "\n";
@@ -812,6 +905,10 @@ int main(int argc, char **argv) {
     } else if (!strcmp(argv[optind], "serialize") ||
                !strcmp(argv[optind], "index")) {
         serialize_run(args);
+    } else {
+        std::cerr << "[E::main] Unknown command: " << argv[optind] << "\n";
+        print_main_help_msg();
+        return 1;
     }
 
     double cpu_duration =

--- a/src/leviosam.cpp
+++ b/src/leviosam.cpp
@@ -105,6 +105,11 @@ uint8_t update_thread_allocation(lift_opts &args) {
         args.lift_threads = args.threads - args.hts_threads;
     } else if (args.lift_threads != DEFAULT_NUM_LIFT_THREADS ||
                args.hts_threads != DEFAULT_NUM_HTS_THREADS) {
+        if (args.lift_threads > INT_MAX - args.hts_threads) {
+            std::cerr << "[E::update_thread_allocation] The sum of "
+                         "--lift_threads and --hts_threads exceeds INT_MAX.\n";
+            return 1;
+        }
         args.threads = args.hts_threads + args.lift_threads;
     }
     std::cerr << "[I::update_thread_allocation] --theads=" << args.threads

--- a/src/leviosam.hpp
+++ b/src/leviosam.hpp
@@ -76,9 +76,9 @@ struct lift_opts {
     std::string split_mode = "";
     std::vector<std::pair<std::string, float>> split_rules;
     int allowed_cigar_changes = 0;
-    uint16_t threads = DEFAULT_NUM_THREADS;
-    uint16_t lift_threads = DEFAULT_NUM_LIFT_THREADS;
-    uint16_t hts_threads = DEFAULT_NUM_HTS_THREADS;
+    int threads = DEFAULT_NUM_THREADS;
+    int lift_threads = DEFAULT_NUM_LIFT_THREADS;
+    int hts_threads = DEFAULT_NUM_HTS_THREADS;
     int chunk_size = 256;
     int verbose = 0;
     int md_flag = 0;
@@ -447,31 +447,10 @@ class LiftMap {
 
     LiftMap(std::ifstream &in) { this->load(in); }
 
-    // copy constructor
-    LiftMap(const LiftMap &rhs)
-        : lmap(rhs.lmap), s1_map(rhs.s1_map), s2_map(rhs.s2_map) {}
-
-    // move constructor
-    LiftMap(LiftMap &&rhs)
-        : lmap(std::move(rhs.lmap)),
-          s1_map(std::move(rhs.s1_map)),
-          s2_map(std::move(s2_map)) {}
-
-    // copy assignment operator
-    LiftMap &operator=(const LiftMap &rhs) {
-        lmap = rhs.lmap;
-        s1_map.clear();
-        s2_map.clear();
-        return *this;
-    }
-
-    // move assignment operator
-    LiftMap &operator=(LiftMap &&rhs) {
-        lmap = std::move(rhs.lmap);
-        s1_map = std::move(s1_map);
-        s2_map = std::move(s2_map);
-        return *this;
-    }
+    LiftMap(const LiftMap &rhs) = default;
+    LiftMap(LiftMap &&rhs) = default;
+    LiftMap &operator=(const LiftMap &rhs) = default;
+    LiftMap &operator=(LiftMap &&rhs) = default;
 
     /* creates a liftover from specified sample in VCF file.
      * input: vcfFile, bcf_hdr_t* of input VCF (via htslib)

--- a/src/leviosam_utils_test.cpp
+++ b/src/leviosam_utils_test.cpp
@@ -13,6 +13,7 @@
 
 #include <unistd.h>
 
+#include <fstream>
 #include <iostream>
 #include <string>
 
@@ -230,6 +231,40 @@ TEST(LiftMap, SimpleBamLift) {
 
     sam_hdr_destroy(sam_hdr);
     sam_close(sam_fp);
+}
+
+TEST(LiftMap, CopyAndMovePreserveSerializedState) {
+    std::ifstream in("major.lft", std::ios::binary);
+    ASSERT_TRUE(in.good());
+    lift::LiftMap original(in);
+
+    char path[] = "/tmp/leviosam2-liftmap-copy-XXXXXX";
+    int fd = mkstemp(path);
+    ASSERT_GE(fd, 0);
+    close(fd);
+    std::ofstream original_out(path, std::ios::binary | std::ios::trunc);
+    size_t original_size = original.serialize(original_out);
+    original_out.close();
+
+    lift::LiftMap copy_assigned;
+    copy_assigned = original;
+    std::ofstream copy_out(path, std::ios::binary | std::ios::trunc);
+    EXPECT_EQ(copy_assigned.serialize(copy_out), original_size);
+    copy_out.close();
+
+    lift::LiftMap copied(original);
+    lift::LiftMap move_assigned;
+    move_assigned = std::move(copied);
+    std::ofstream move_assignment_out(path,
+                                      std::ios::binary | std::ios::trunc);
+    EXPECT_EQ(move_assigned.serialize(move_assignment_out), original_size);
+    move_assignment_out.close();
+
+    lift::LiftMap moved(std::move(original));
+    std::ofstream move_out(path, std::ios::binary | std::ios::trunc);
+    EXPECT_EQ(moved.serialize(move_out), original_size);
+    move_out.close();
+    unlink(path);
 }
 
 TEST(LiftMap, SimpleBamCigarLift) {

--- a/tests/cli_index_lift_test.cmake
+++ b/tests/cli_index_lift_test.cmake
@@ -154,3 +154,13 @@ foreach(INVALID_ARGS "-T;0" "-t;not-a-number" "-G;-1")
         message(FATAL_ERROR "invalid arguments were accepted: ${INVALID_ARGS}")
     endif()
 endforeach()
+
+execute_process(
+    COMMAND "${LEVIOSAM2}" lift -C "${INDEX_PREFIX}.clft" -a "${SAM}"
+            -p "${TEST_TMP_DIR}/invalid-thread-sum"
+            --lift_threads 2147483647 --hts_threads 2147483647
+    RESULT_VARIABLE INVALID_THREAD_SUM_RESULT
+    OUTPUT_QUIET ERROR_QUIET)
+if(INVALID_THREAD_SUM_RESULT EQUAL 0)
+    message(FATAL_ERROR "overflowing thread sum was accepted")
+endif()

--- a/tests/cli_index_lift_test.cmake
+++ b/tests/cli_index_lift_test.cmake
@@ -160,7 +160,13 @@ execute_process(
             -p "${TEST_TMP_DIR}/invalid-thread-sum"
             --lift_threads 2147483647 --hts_threads 2147483647
     RESULT_VARIABLE INVALID_THREAD_SUM_RESULT
-    OUTPUT_QUIET ERROR_QUIET)
-if(INVALID_THREAD_SUM_RESULT EQUAL 0)
-    message(FATAL_ERROR "overflowing thread sum was accepted")
+    OUTPUT_QUIET ERROR_VARIABLE INVALID_THREAD_SUM_STDERR)
+string(FIND "${INVALID_THREAD_SUM_STDERR}"
+       "The sum of --lift_threads and --hts_threads exceeds INT_MAX"
+       INVALID_THREAD_SUM_MESSAGE_POS)
+if(NOT INVALID_THREAD_SUM_RESULT EQUAL 21 OR
+   INVALID_THREAD_SUM_MESSAGE_POS EQUAL -1)
+    message(FATAL_ERROR
+        "overflowing thread sum did not fail cleanly: "
+        "exit=${INVALID_THREAD_SUM_RESULT}, stderr=${INVALID_THREAD_SUM_STDERR}")
 endif()

--- a/tests/cli_index_lift_test.cmake
+++ b/tests/cli_index_lift_test.cmake
@@ -1,0 +1,156 @@
+if(NOT DEFINED LEVIOSAM2 OR NOT DEFINED TEST_TMP_DIR)
+    message(FATAL_ERROR "LEVIOSAM2 and TEST_TMP_DIR are required")
+endif()
+
+file(REMOVE_RECURSE "${TEST_TMP_DIR}")
+file(MAKE_DIRECTORY "${TEST_TMP_DIR}")
+
+set(CHAIN "${TEST_TMP_DIR}/tiny.chain")
+set(FAI "${TEST_TMP_DIR}/target.fai")
+set(SAM "${TEST_TMP_DIR}/input.sam")
+set(INDEX_PREFIX "${TEST_TMP_DIR}/tiny")
+
+file(WRITE "${CHAIN}"
+    "chain 1 src 1000 + 100 200 dst 1000 + 300 400 1\n"
+    "50 0 0\n"
+    "50\n\n"
+    "chain 1 revsrc 1000 + 100 200 revdst 1000 - 600 700 2\n"
+    "50 0 0\n"
+    "50\n")
+file(WRITE "${FAI}" "dst\t1000\nrevdst\t1000\n")
+file(WRITE "${SAM}"
+    "@HD\tVN:1.6\tSO:unsorted\n"
+    "@SQ\tSN:src\tLN:1000\n"
+    "@SQ\tSN:revsrc\tLN:1000\n"
+    "forward\t0\tsrc\t111\t60\t10M\t*\t0\t0\tAAAAAAAAAA\tIIIIIIIIII\n"
+    "forward-cross\t0\tsrc\t146\t60\t20M\t*\t0\t0\tAAAAAAAAAAAAAAAAAAAA\tIIIIIIIIIIIIIIIIIIII\n"
+    "reverse\t0\trevsrc\t111\t60\t10M\t*\t0\t0\tAAAAAAAAAA\tIIIIIIIIII\n"
+    "reverse-cross\t0\trevsrc\t146\t60\t20M\t*\t0\t0\tAAAAAAAAAAAAAAAAAAAA\tIIIIIIIIIIIIIIIIIIII\n")
+
+execute_process(
+    COMMAND "${LEVIOSAM2}" index -c "${CHAIN}" -F "${FAI}" -p "${INDEX_PREFIX}"
+    RESULT_VARIABLE INDEX_RESULT
+    OUTPUT_VARIABLE INDEX_STDOUT
+    ERROR_VARIABLE INDEX_STDERR)
+if(NOT INDEX_RESULT EQUAL 0 OR NOT EXISTS "${INDEX_PREFIX}.clft")
+    message(FATAL_ERROR "index failed (${INDEX_RESULT}): ${INDEX_STDERR}")
+endif()
+
+set(LIFT_PREFIX "${TEST_TMP_DIR}/lifted")
+execute_process(
+    COMMAND "${LEVIOSAM2}" lift -C "${INDEX_PREFIX}.clft" -a "${SAM}"
+            -p "${LIFT_PREFIX}" -O sam
+    RESULT_VARIABLE LIFT_RESULT
+    OUTPUT_VARIABLE LIFT_STDOUT
+    ERROR_VARIABLE LIFT_STDERR)
+if(NOT LIFT_RESULT EQUAL 0)
+    message(FATAL_ERROR "indexed lift failed (${LIFT_RESULT}): ${LIFT_STDERR}")
+endif()
+file(READ "${LIFT_PREFIX}.sam" LIFTED)
+
+foreach(EXPECTED
+        "forward\t0\tdst\t311\t60\t10M\t*\t0\t0\tAAAAAAAAAA\tIIIIIIIIII\tLO:Z:L"
+        "forward-cross\t0\tdst\t346\t60\t20M\t*\t0\t0\tAAAAAAAAAAAAAAAAAAAA\tIIIIIIIIIIIIIIIIIIII\tLO:Z:L"
+        "reverse\t16\trevdst\t381\t60\t10M\t*\t0\t0\tTTTTTTTTTT\tIIIIIIIIII\tLO:Z:L"
+        "reverse-cross\t16\trevdst\t336\t60\t20M\t*\t0\t0\tTTTTTTTTTTTTTTTTTTTT\tIIIIIIIIIIIIIIIIIIII\tLO:Z:L")
+    string(FIND "${LIFTED}" "${EXPECTED}" MATCH_POS)
+    if(MATCH_POS EQUAL -1)
+        message(FATAL_ERROR "missing expected lifted record: ${EXPECTED}\n${LIFTED}")
+    endif()
+endforeach()
+
+# Exercise direct chain construction and guard against -B falling through to -c.
+set(DIRECT_PREFIX "${TEST_TMP_DIR}/direct")
+execute_process(
+    COMMAND "${LEVIOSAM2}" lift -c "${CHAIN}" -B 0.5 -F "${FAI}"
+            -a "${SAM}" -p "${DIRECT_PREFIX}" -O sam
+    RESULT_VARIABLE DIRECT_RESULT
+    OUTPUT_VARIABLE DIRECT_STDOUT
+    ERROR_VARIABLE DIRECT_STDERR)
+if(NOT DIRECT_RESULT EQUAL 0)
+    message(FATAL_ERROR "direct lift failed (${DIRECT_RESULT}): ${DIRECT_STDERR}")
+endif()
+file(READ "${DIRECT_PREFIX}.sam" DIRECT_LIFTED)
+string(FIND "${DIRECT_LIFTED}" "forward\t0\tdst\t311\t60\t10M" DIRECT_POS)
+if(DIRECT_POS EQUAL -1)
+    message(FATAL_ERROR "direct lift produced an unexpected record: ${DIRECT_LIFTED}")
+endif()
+
+set(MISSING_PREFIX "${TEST_TMP_DIR}/missing")
+execute_process(
+    COMMAND "${LEVIOSAM2}" index -c "${TEST_TMP_DIR}/missing.chain"
+            -F "${FAI}" -p "${MISSING_PREFIX}"
+    RESULT_VARIABLE MISSING_RESULT
+    OUTPUT_QUIET ERROR_QUIET)
+if(MISSING_RESULT EQUAL 0 OR EXISTS "${MISSING_PREFIX}.clft")
+    message(FATAL_ERROR "missing chain input was accepted")
+endif()
+
+execute_process(
+    COMMAND "${LEVIOSAM2}" index -c "${CHAIN}"
+            -F "${TEST_TMP_DIR}/missing.fai" -p "${TEST_TMP_DIR}/missing-fai"
+    RESULT_VARIABLE MISSING_FAI_RESULT
+    OUTPUT_QUIET ERROR_QUIET)
+if(MISSING_FAI_RESULT EQUAL 0 OR EXISTS "${TEST_TMP_DIR}/missing-fai.clft")
+    message(FATAL_ERROR "missing FAI input was accepted")
+endif()
+
+file(WRITE "${TEST_TMP_DIR}/malformed.chain" "chain malformed\n")
+execute_process(
+    COMMAND "${LEVIOSAM2}" index -c "${TEST_TMP_DIR}/malformed.chain"
+            -F "${FAI}" -p "${TEST_TMP_DIR}/malformed"
+    RESULT_VARIABLE MALFORMED_RESULT
+    OUTPUT_QUIET ERROR_QUIET)
+if(MALFORMED_RESULT EQUAL 0)
+    message(FATAL_ERROR "malformed chain input was accepted")
+endif()
+
+execute_process(
+    COMMAND "${LEVIOSAM2}" unknown-command
+    RESULT_VARIABLE UNKNOWN_RESULT
+    OUTPUT_QUIET ERROR_QUIET)
+if(UNKNOWN_RESULT EQUAL 0)
+    message(FATAL_ERROR "unknown command returned success")
+endif()
+
+execute_process(
+    COMMAND "${LEVIOSAM2}" --version
+    RESULT_VARIABLE VERSION_RESULT
+    OUTPUT_VARIABLE VERSION_STDOUT
+    ERROR_VARIABLE VERSION_STDERR)
+if(NOT VERSION_RESULT EQUAL 0 OR VERSION_STDOUT STREQUAL "")
+    message(FATAL_ERROR "global --version failed (${VERSION_RESULT}): ${VERSION_STDERR}")
+endif()
+
+file(WRITE "${TEST_TMP_DIR}/empty.clft" "")
+foreach(MISSING_INDEX "${TEST_TMP_DIR}/missing.clft" "${TEST_TMP_DIR}/empty.clft")
+    execute_process(
+        COMMAND "${LEVIOSAM2}" lift -C "${MISSING_INDEX}" -a "${SAM}"
+                -p "${TEST_TMP_DIR}/bad-index"
+        RESULT_VARIABLE BAD_INDEX_RESULT
+        OUTPUT_QUIET ERROR_QUIET)
+    if(BAD_INDEX_RESULT EQUAL 0)
+        message(FATAL_ERROR "missing/empty ChainMap index was accepted: ${MISSING_INDEX}")
+    endif()
+endforeach()
+
+execute_process(
+    COMMAND "${LEVIOSAM2}" lift -C "${INDEX_PREFIX}.clft"
+            -a "${TEST_TMP_DIR}/missing.sam" -p "${TEST_TMP_DIR}/bad-input"
+            --hts_threads 1
+    RESULT_VARIABLE BAD_INPUT_RESULT
+    OUTPUT_QUIET ERROR_QUIET)
+if(BAD_INPUT_RESULT EQUAL 0)
+    message(FATAL_ERROR "missing alignment input was accepted")
+endif()
+
+foreach(INVALID_ARGS "-T;0" "-t;not-a-number" "-G;-1")
+    execute_process(
+        COMMAND "${LEVIOSAM2}" lift -C "${INDEX_PREFIX}.clft" -a "${SAM}"
+                -p "${TEST_TMP_DIR}/invalid" ${INVALID_ARGS}
+        RESULT_VARIABLE INVALID_RESULT
+        OUTPUT_QUIET ERROR_QUIET)
+    if(INVALID_RESULT EQUAL 0)
+        message(FATAL_ERROR "invalid arguments were accepted: ${INVALID_ARGS}")
+    endif()
+endforeach()


### PR DESCRIPTION
## Summary
- add dependency-free CLI integration coverage for index-to-CLFT-to-lift, forward and reverse multi-interval lifts, direct-chain lifting, and invalid inputs
- fix multi-interval breakpoint bounds and reverse-strand interval-gap calculation
- remove undefined behavior in CIGAR expansion and preserve LiftMap state across copy and move
- validate numeric CLI options and propagate common input/output failures

## Severity
No confirmed P0 issue was found. The core P1 fixes cover valid supported lift paths: unsafe multi-interval breakpoint access, an incorrect reverse multi-interval legality transform, undefined behavior during CIGAR expansion, and broken LiftMap copy/move state. Missing-file and malformed-option handling are P2 robustness improvements.

## Tests
- `pixi run test` — 6/6 passed
- ASan + UBSan CTest build — 6/6 passed
- `git diff --check` — clean

## Follow-up
Broader behavioral coverage, integration-test hardening, refactoring, documentation, and CI coverage remain planned for later iterations.